### PR TITLE
feat(content): real career timeline, CEIA fellowship & writing section

### DIFF
--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -13,7 +13,7 @@ import ScrollStage from "@/components/layout/ScrollStage";
 import Section from "@/components/layout/Section";
 import ContentScrim from "@/components/layout/ContentScrim";
 import { profile } from "@/lib/content";
-import { FaGithub, FaLinkedinIn, FaInstagram } from "react-icons/fa";
+import { FaGithub, FaLinkedinIn, FaInstagram, FaMedium } from "react-icons/fa";
 import { FaXTwitter } from "react-icons/fa6";
 import { FiCopy, FiCheck, FiCalendar, FiArrowUpRight } from "react-icons/fi";
 import { getColorValue } from "@/lib/colors";
@@ -38,10 +38,16 @@ const socialLinks = [
     fragment: "/in/matheuskindrazki",
   },
   {
+    href: profile.social.medium,
+    icon: FaMedium,
+    label: "Medium",
+    fragment: "@matheuskindrazki",
+  },
+  {
     href: profile.social.instagram,
     icon: FaInstagram,
     label: "Instagram",
-    fragment: "@kindrazki",
+    fragment: "@matheuskindrazki",
   },
   {
     href: profile.social.twitter,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   FiTwitter,
   FiArrowUpRight,
 } from "react-icons/fi";
+import { FaMedium } from "react-icons/fa";
 import PageNav from "@/components/ui/PageNav";
 import JarvisTrigger from "@/components/chat/JarvisTrigger";
 import PageShell, { useShellNav } from "@/components/layout/PageShell";
@@ -35,6 +36,7 @@ const HOME_PORTRAIT_SRC = "/images/kindra-home.png";
 const socialLinks = [
   { href: profile.social.github, label: "GitHub", Icon: FiGithub },
   { href: profile.social.linkedin, label: "LinkedIn", Icon: FiLinkedin },
+  { href: profile.social.medium, label: "Medium", Icon: FaMedium },
   { href: profile.social.instagram, label: "Instagram", Icon: FiInstagram },
   { href: profile.social.twitter, label: "X/Twitter", Icon: FiTwitter },
 ];

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -10,7 +10,7 @@ import PageShell, { useShellNav } from "@/components/layout/PageShell";
 import ScrollStage from "@/components/layout/ScrollStage";
 import Section from "@/components/layout/Section";
 import ContentScrim from "@/components/layout/ContentScrim";
-import { timeline, philosophy } from "@/lib/content";
+import { timeline, philosophy, writing } from "@/lib/content";
 import { getColorValue } from "@/lib/colors";
 import { stagger, fadeUp, enterAt } from "@/lib/motion";
 import styles from "./sobre.module.css";
@@ -85,10 +85,12 @@ function SobreContent() {
             className="enter-rise max-w-[540px] font-normal text-[length:var(--text-body)] leading-[1.7] text-[var(--color-kindra-meta-high)]"
             style={{ ...enterAt(2), fontFamily: "var(--font-body)" }}
           >
-            Co-founder at <Mark color="yellow">MokLabs Venture Studio</Mark>{" "}
-            and founding team at Lugui.ai. 8 years architecting platforms at
-            Arco Educação — shipping infrastructure that reached millions of
-            students. Now turning that experience into ventures of my own.
+            Co-founder at <Mark color="yellow">MokLabs Venture Studio</Mark>,
+            founding team at Lugui.ai, and{" "}
+            <Mark color="yellow">AI Research Fellow at CEIA (UFG)</Mark>. Nearly
+            a decade architecting platforms at Arco Educação — shipping
+            infrastructure that reached millions of students. Now turning that
+            experience into ventures of my own.
           </p>
 
           <PageNav current="/sobre" onClick={onNavClick} />
@@ -100,7 +102,7 @@ function SobreContent() {
             className={styles.scrollHint}
           >
             <span className={styles.scrollHintRule} />
-            <span>scroll &middot; journey &middot; philosophy &middot; formation</span>
+            <span>scroll &middot; journey &middot; philosophy &middot; writing</span>
             <span aria-hidden className={`animate-bounce ${styles.scrollHintArrow}`}>
               ↓
             </span>
@@ -179,7 +181,53 @@ function SobreContent() {
         </motion.div>
       </Section>
 
-      {/* Section 4 — Formation / closing */}
+      {/* Section 4 — Writing */}
+      <Section align="left" measure="wide">
+        <motion.div
+          variants={stagger}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true }}
+        >
+          <motion.div variants={fadeUp}>
+            <Eyebrow label="writing" accent={yellow} />
+          </motion.div>
+
+          <motion.h2 variants={fadeUp} className={`mt-4 ${styles.sectionTitle}`}>
+            Thinking{" "}
+            <span className={styles.sectionTitleNote}>out loud</span>
+          </motion.h2>
+
+          <div className={styles.writingList}>
+            {writing.map((article) => (
+              <motion.a
+                key={article.title}
+                variants={fadeUp}
+                href={article.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-cursor="link"
+                className={styles.writingItem}
+              >
+                <span className={styles.writingMeta}>
+                  {article.year} · {article.topic}
+                </span>
+                <h3 className={styles.writingTitle}>{article.title}</h3>
+                <p className={styles.writingBlurb}>{article.blurb}</p>
+              </motion.a>
+            ))}
+          </div>
+
+          <motion.div variants={fadeUp}>
+            <MetaRow
+              className="mt-10"
+              items={["medium", "matheuskindrazki.medium.com", "more on the feed →"]}
+            />
+          </motion.div>
+        </motion.div>
+      </Section>
+
+      {/* Section 5 — Formation / closing */}
       <Section align="left">
         <motion.div
           variants={stagger}
@@ -195,8 +243,8 @@ function SobreContent() {
             <span className={styles.formationLeadStrong}>
               Software Engineering
             </span>{" "}
-            — specialized in <Mark color="yellow">Cloud Computing</Mark> (AWS,
-            Azure) &amp; DevOps.
+            — PUC-PR (2019–2024), specialized in{" "}
+            <Mark color="yellow">Cloud Computing</Mark> (AWS) &amp; DevOps.
           </motion.p>
 
           <motion.p variants={fadeUp} className={styles.formationBody}>

--- a/src/app/sobre/sobre.module.css
+++ b/src/app/sobre/sobre.module.css
@@ -199,6 +199,60 @@
   line-height: 1.55;
 }
 
+/* ── Writing ─────────────────────────────────────────────────────── */
+.writingList {
+  margin-top: 28px;
+  display: flex;
+  flex-direction: column;
+}
+
+.writingItem {
+  display: block;
+  padding: 18px 0;
+  border-top: 1px solid var(--color-kindra-rule);
+  text-decoration: none;
+  transition: opacity 0.4s var(--ease-smooth);
+}
+
+.writingItem:last-child {
+  border-bottom: 1px solid var(--color-kindra-rule);
+}
+
+.writingMeta {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--color-kindra-meta-low);
+  font-family: var(--font-data);
+  font-size: var(--text-data);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-variant-numeric: tabular-nums;
+}
+
+.writingTitle {
+  margin: 0 0 6px;
+  max-width: 720px;
+  color: color-mix(in srgb, var(--color-kindra-text-white) 88%, transparent);
+  font-family: var(--font-heading);
+  font-size: var(--text-deck);
+  font-weight: 700;
+  line-height: 1.25;
+  transition: color 0.4s var(--ease-smooth);
+}
+
+.writingItem:hover .writingTitle {
+  color: var(--color-kindra-yellow);
+}
+
+.writingBlurb {
+  margin: 0;
+  max-width: 620px;
+  color: var(--color-kindra-meta-mid);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
 /* ── Formation / closing ─────────────────────────────────────────── */
 .formationLead {
   max-width: 560px;

--- a/src/components/layout/PageChrome.tsx
+++ b/src/components/layout/PageChrome.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import Identity from "@/components/ui/Identity";
 import { useLiveTime } from "@/hooks/useLiveTime";
-import { site } from "@/lib/content";
 import shell from "./shell.module.css";
 
 interface PageChromeProps {
@@ -93,9 +92,6 @@ export default function PageChrome({
           </div>
           <div className={`mt-2 ${shell.chromeClock}`}>{time}</div>
           <div className="mt-0.5">Curitiba · BRT · -25.42° -49.27°</div>
-          <div>
-            portfolio · {site.version} · {site.year}
-          </div>
         </div>
       </motion.div>
 

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -45,29 +45,29 @@ export const profile = {
   title: 'Co-founder & Builder',
   company: 'MokLabs Venture Studio',
   secondaryRole: 'Founding team at Lugui.ai',
+  fellowship: 'AI Research Fellow · CEIA (UFG)',
   email: 'matheus@kindrazki.dev',
   location: 'Curitiba, Brazil',
   bio: 'Hey — my name is Matheus, but you can call me Kindra =)',
   headline: 'Building ventures where bold ideas meet careful engineering.',
   description:
-    'Co-founder at MokLabs Venture Studio and part of the founding team at Lugui.ai. Engineering since 2017, architecting platforms used by millions of students — now turning that experience into products of my own. Technology adventurer, pragmatic builder.',
+    'Co-founder at MokLabs Venture Studio, founding team at Lugui.ai, and AI Research Fellow at CEIA (UFG). A decade architecting platforms used by millions of students at Arco Educação — now turning that experience into products of my own. Technology adventurer, pragmatic builder.',
   calLink: 'https://cal.com/matheuskindrazki',
   social: {
     github: 'https://github.com/MatheusKindrazki',
     linkedin: 'https://linkedin.com/in/matheuskindrazki',
-    instagram: 'https://instagram.com/kindrazki',
+    medium: 'https://matheuskindrazki.medium.com',
+    instagram: 'https://instagram.com/matheuskindrazki',
     twitter: 'https://x.com/kindraScript',
   },
 }
 
 /**
- * Site-wide rot-prone strings, kept in ONE place so the version/date stamp in
- * the chrome, the home footer, and the /now page never disagree. Both date
- * fields derive from the build-time git stamp — never edit them by hand.
+ * Site-wide rot-prone strings, kept in ONE place so the date stamp in the home
+ * footer and the /now page never disagree. Both date fields derive from the
+ * build-time git stamp — never edit them by hand.
  */
 export const site = {
-  version: 'v3.0',
-  year: '2026',
   /** e.g. 'jun 2026' */
   lastUpdated: formatMonthYear(contentUpdatedIso),
   /** YYYY-MM-DD */
@@ -142,6 +142,21 @@ export const projects: Project[] = [
     nowNote:
       'Tutoring systems that actually understand what a student just missed — frontend, RAG pipelines, and the DX that keeps a small team fast.',
     nowStatus: 'alpha',
+  },
+  {
+    title: 'CEIA — AI Research Fellow',
+    description:
+      'AI Research Fellow at the Centro de Excelência em Inteligência Artificial (CEIA / UFG) — applied research at the frontier of LLMs and intelligent systems, bridging academic rigor and shipped products.',
+    tags: ['Applied Research', 'LLMs', 'Intelligent Systems', 'CEIA', 'UFG'],
+    color: 'green',
+    year: '2026',
+    status: 'current',
+    signal: 'research',
+    role: 'research fellow',
+    coordinate: 'frontier/llm',
+    nowNote:
+      'Applied AI research at CEIA (UFG) — frontier LLM work bridging academic rigor and shipped products.',
+    nowStatus: 'in-progress',
   },
   {
     title: 'Synk',
@@ -289,12 +304,47 @@ export const philosophy = [
 ]
 
 export const timeline = [
-  { year: '2017', title: 'Started as a Backend Developer', description: 'First steps as a backend developer with PHP.' },
-  { year: '2018', title: 'Transitioned to Frontend', description: 'Discovered a passion for interfaces and user experience.' },
-  { year: '2020', title: 'Joined Arco Educação', description: 'Came in as a frontend engineer at the largest education company in Brazil.' },
-  { year: '2022', title: 'Tech Lead', description: 'Technical leadership of teams, microfrontend architecture.' },
-  { year: '2024', title: 'Principal Engineer', description: 'Architecture at scale, governance, DX, and AI initiatives.' },
-  { year: '2025', title: 'Founder Era', description: 'Co-founded MokLabs Venture Studio. Joined the founding team at Lugui.ai. Adventuring at the edges of technology.' },
+  { year: '2017', title: 'First lines shipped', description: 'Mobile and web internships (UFPR, Corpo de Bombeiros PR) then agency work — PHP, WordPress, Node.js, React Native for real clients.' },
+  { year: '2019', title: 'Engineering Manager', description: 'Led a small team at Mentores Digital: custom client platforms, APIs (Express/Adonis), React & React Native apps, ERP integrations.' },
+  { year: '2020', title: 'Joined Arco Educação', description: 'Came in as a Software Engineer at one of Brazil’s largest edtechs — frontend platform work across pedagogical products.' },
+  { year: '2021', title: 'Staff Engineer', description: 'Stepped up to Staff: microfrontend architecture with Module Federation, design-system governance, and DX across squads.' },
+  { year: '2025', title: 'Principal Engineer — Applied AI', description: 'Led the Applied AI & AI Platform front: RAG over large document bases, automated essay correction (OCR/HTR), and AI infra reaching millions of students.' },
+  { year: '2026', title: 'Founder & Research Fellow', description: 'Co-founded MokLabs, joined the founding team at Lugui.ai, and became an AI Research Fellow at CEIA (UFG). Turning a decade of platform work into ventures of my own.' },
+]
+
+/**
+ * Selected technical writing (Medium: matheuskindrazki.medium.com). Curated —
+ * the strongest pieces on LLM engineering and architecture, not the full feed.
+ */
+export const writing = [
+  {
+    title: 'Contexto Demais Apodrece: o Ponto Ótimo da Janela nos LLMs',
+    blurb: 'Context engineering — calibrating the ideal window to cut noise and hallucination.',
+    year: '2025',
+    topic: 'LLM Engineering',
+    link: 'https://matheuskindrazki.medium.com/',
+  },
+  {
+    title: 'Criatividade é um Bug: Como a Matemática (e não o Prompt) vai salvar seu SaaS',
+    blurb: 'Trading the uncertainty of language for the guarantees of automata to scale AI products.',
+    year: '2025',
+    topic: 'Applied AI',
+    link: 'https://matheuskindrazki.medium.com/',
+  },
+  {
+    title: 'Ainda Não Chegamos Lá: O Hype da IA vs. a Realidade Atual',
+    blurb: 'Why AI still fails at complex problems, what the benchmarks really show, and how to adopt strategically.',
+    year: '2025',
+    topic: 'AI Strategy',
+    link: 'https://matheuskindrazki.medium.com/',
+  },
+  {
+    title: 'Como gerenciar rotas compartilhadas em aplicações Microfrontends',
+    blurb: 'Essential strategies for a consistent, integrated UX across federated microfrontends.',
+    year: '2023',
+    topic: 'Architecture',
+    link: 'https://matheuskindrazki.medium.com/',
+  },
 ]
 
 export const navLinks = [


### PR DESCRIPTION
## Resumo

Enriquece o conteúdo do portfólio com fatos reais de carreira (LinkedIn + Medium + Jarvis). Continuação direta do #32 — este commit ficou de fora do merge daquela PR.

## O que mudou

- **Timeline real no /sobre** — substitui datas/cargos imprecisos pela progressão verdadeira: 2017 (primeiros projetos/estágios) → 2019 Engineering Manager → 2020 Arco (Software Engineer) → 2021 Staff Engineer → 2025 Principal Engineer, Applied AI → 2026 Founder & Research Fellow. Formação corrigida para PUC-PR, Eng. de Software (2019–2024).
- **CEIA (UFG)** — AI Research Fellow adicionado como posição atual: nó no atlas de /projetos, na descrição do hero e no lede do /sobre.
- **Seção "Writing"** no /sobre — 4 artigos curados do Medium (LLM engineering, applied AI, arquitetura) + Medium adicionado aos links sociais (home + contato).
- **Correções** — handle do Instagram para `matheuskindrazki` (estava `kindrazki`/`@kindrazki`); remoção do stamp "portfolio · v3.0 · 2026" do chrome (e dos campos `site.version`/`year` órfãos).

## Verificação
`npx tsc --noEmit` limpo · `npx next build` 0 erros / 0 warnings · verificado no browser (timeline, seção Writing, nó CEIA no atlas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adicionada nova seção "Writing" na página Sobre com lista de artigos curados.
  * Integrado link para o Medium nas redes sociais.

* **Updates**
  * Atualizado HUD com exibição de hora local e coordenadas geográficas.
  * Revisado conteúdo do perfil com novos projetos e timeline atualizada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->