### PR TITLE
chore(ci): add Dependabot config for the Next.js stack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot config — keep updates useful, not noisy.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Cap open PRs so they never pile up like the old CRA-era backlog.
+    open-pull-requests-limit: 5
+    # Batch related bumps into a few PRs instead of one-per-package.
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # Framework majors need a coordinated manual upgrade (e.g. Next 15 → 16),
+    # so let Dependabot flag security patches but not open major-bump PRs.
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
O repo não tinha `.github/dependabot.yml`, então o Dependabot rodava nos defaults e acumulou 24 PRs antigos da stack CRA/Webpack (todos fechados agora). Esta config alinha ele ao projeto atual:

- npm, semanal, agrupando updates **prod** e **dev** (minor+patch) em poucos PRs
- limite de **5 PRs abertos** (evita o acúmulo de novo)
- ignora **majors** de next/react/react-dom (upgrade manual coordenado, como o next 15→16)
- também monitora github-actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)