### PR TITLE
feat(responsive): mobile flow under 820px — fix unreachable content + touch UX

### DIFF
--- a/src/app/contato/contato.module.css
+++ b/src/app/contato/contato.module.css
@@ -1,0 +1,58 @@
+/* ──────────────────────────────────────────────────────────────────
+   /contato — mobile-flow spacing.
+
+   The route stacks two <Section>s (hero+socials, then the form). On desktop
+   each is its own 100vh snap panel so the shared .section padding-block-lg
+   reads as breathing room. Below the 820px shell release the sections become
+   normal in-flow blocks (min-height:auto) and that large padding stacks —
+   Section 1's bottom pad + Section 2's top pad — leaving a dead vertical gap
+   between the socials and the form. Collapse the seam between them on mobile
+   while keeping the page's outer top/bottom rhythm. Desktop (>=820px) is
+   untouched — these rules live entirely inside the 820px media query.
+
+   Selectors are scoped under .stage (the ScrollStage wrapper) and target the
+   real <section> elements, so they out-specify the shared .section rule from
+   shell.module.css regardless of CSS-module load order.
+   ─────────────────────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  /* The seam between the two stacked panels: drop the first section's bottom
+     pad and tighten the second's top pad so they meet on one calm seam instead
+     of summing two section-pad-lg blocks. The outer top/bottom rhythm of the
+     page (first section's top, last section's bottom) is left intact. */
+  .stage > section:first-child {
+    padding-bottom: 0;
+  }
+  .stage > section:last-child {
+    padding-top: var(--section-pad-sm);
+  }
+}
+
+/* Touch UX — reveal the hover-only affordances (the email copy chip, the
+   "book a chat" arrow) on devices that cannot hover, so they are visible and
+   usable instead of permanently invisible. Scoped under .stage to out-specify
+   the Tailwind opacity-0 / -translate-x utilities; only applies where there is
+   no hover, so pointer/desktop is unchanged. */
+@media (hover: none) {
+  .stage .touchReveal {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Touch tap targets — the social rows author their vertical rhythm with
+   Tailwind `py-3` and the calendar link is a plain text line, but the
+   unlayered `* { padding: 0 }` reset in globals.css zeroes Tailwind padding
+   utilities, so on touch these collapse to a ~21px line — under the 44px
+   minimum. CSS modules emit unlayered → these win. Give each a real >=44px
+   hit area (and restore the social rows' intended vertical padding) on coarse
+   pointers only, so the desktop hover layout/aesthetic is unchanged. */
+@media (pointer: coarse) {
+  .socialRow {
+    min-height: 44px;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  .calLink {
+    min-height: 44px;
+  }
+}

--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -18,6 +18,7 @@ import { FaXTwitter } from "react-icons/fa6";
 import { FiCopy, FiCheck, FiCalendar, FiArrowUpRight } from "react-icons/fi";
 import { getColorValue } from "@/lib/colors";
 import { stagger, fadeUp, enterAt } from "@/lib/motion";
+import styles from "./contato.module.css";
 
 const ParticlePhoto = dynamic(
   () => import("@/components/canvas/ParticlePhoto"),
@@ -107,7 +108,7 @@ function ContatoContent() {
   }, []);
 
   return (
-    <ScrollStage>
+    <ScrollStage className={styles.stage}>
       {/* Section 1 - Hero + email CTA + socials. Enters via the CSS
           `.enter-rise` idiom (globals.css), not framer `initial="hidden"` —
           the SSR HTML must paint the h1 before the pixi-heavy bundle
@@ -163,7 +164,7 @@ function ContatoContent() {
                 {profile.email}
               </a>
               <span
-                className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[var(--color-kindra-rule)] text-[var(--color-kindra-meta-mid)] opacity-0 transition-all duration-500 group-hover/email:opacity-100 group-hover/email:border-[var(--color-kindra-rule-strong)] group-hover/email:text-[var(--color-kindra-text-white)]"
+                className={`${styles.touchReveal} inline-flex h-7 w-7 items-center justify-center rounded-full border border-[var(--color-kindra-rule)] text-[var(--color-kindra-meta-mid)] opacity-0 transition-all duration-500 group-hover/email:opacity-100 group-hover/email:border-[var(--color-kindra-rule-strong)] group-hover/email:text-[var(--color-kindra-text-white)]`}
                 title={copied ? "Copied" : "Copy email"}
               >
                 <AnimatePresence mode="wait" initial={false}>
@@ -219,7 +220,7 @@ function ContatoContent() {
               target="_blank"
               rel="noopener noreferrer"
               data-cursor="link"
-              className="group/cal inline-flex items-center gap-3 text-[length:var(--text-body)] tracking-[0.05em] text-[var(--color-kindra-meta-high)] transition-colors duration-700 hover:text-[var(--color-kindra-text-white)]"
+              className={`group/cal ${styles.calLink} inline-flex items-center gap-3 text-[length:var(--text-body)] tracking-[0.05em] text-[var(--color-kindra-meta-high)] transition-colors duration-700 hover:text-[var(--color-kindra-text-white)]`}
               style={{
                 fontFamily: "var(--font-body)",
                 transitionTimingFunction: "var(--ease-smooth)",
@@ -238,7 +239,7 @@ function ContatoContent() {
                 />
               </span>
               <FiArrowUpRight
-                className="text-[13px] -translate-x-1 opacity-0 transition-all duration-700 group-hover/cal:translate-x-0 group-hover/cal:opacity-100"
+                className={`${styles.touchReveal} text-[13px] -translate-x-1 opacity-0 transition-all duration-700 group-hover/cal:translate-x-0 group-hover/cal:opacity-100`}
                 style={{ color: red }}
               />
             </a>
@@ -257,7 +258,7 @@ function ContatoContent() {
                     href={href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="group/row relative flex items-center gap-4 border-b border-[var(--color-kindra-rule)] py-3 pl-4 transition-colors duration-700"
+                    className={`group/row ${styles.socialRow} relative flex items-center gap-4 border-b border-[var(--color-kindra-rule)] py-3 pl-4 transition-colors duration-700`}
                     style={{
                       transitionTimingFunction: "var(--ease-smooth)",
                     }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,6 +107,27 @@ body {
     justify-content: center;
 }
 
+/* Below the 820px shell release the shell is height:auto and can be taller
+   than the viewport. The desktop body centers its single child (the fixed
+   100vh shell) vertically — but on a taller-than-viewport released shell that
+   centering pushes the top of the page ABOVE the viewport (negative offset)
+   and, because html/body are locked to height:100%, the document cannot scroll
+   to reach it (the /contato P0: "Contact" h1 clipped at top, bottom cut,
+   maxScroll:0). Anchor the shell to the top and let the document grow + scroll
+   so every released route (contato/now/skills/…) flows naturally. Desktop
+   (>=820px) keeps the exact centering above — untouched. */
+@media (max-width: 820px) {
+    html,
+    body {
+        height: auto;
+        min-height: 100svh;
+    }
+    body {
+        align-items: flex-start;
+        justify-content: flex-start;
+    }
+}
+
 ::selection {
     background-color: rgba(224, 164, 88, 0.3);
     color: #fff;
@@ -158,6 +179,36 @@ details:focus-visible,
    since there's no native cursor to visually anchor the user */
 body.custom-cursor-active :focus-visible {
     outline-offset: 3px;
+}
+
+/* ── Touch tap-target expansion ──────────────────────────────────────
+   Many chrome links are small text (nav links ~21px, the "back"/"now"
+   links, social icons, the jarvis trigger). On a coarse pointer that is
+   below the 44px minimum hit target. This expands the clickable region
+   to >=44px WITHOUT changing the visual text size or shifting layout: an
+   absolutely-centered ::after overlays a 44px-tall (and at least as wide)
+   transparent hit surface on top of the element. It is gated to
+   `pointer: coarse` so desktop hover/underline aesthetics are untouched,
+   and only kicks in where the box would otherwise be too small (the
+   pseudo never shrinks a target that is already >=44px). The host must be
+   `position: relative` (most of these are inline-block/inline-flex and we
+   add relative where needed). */
+@media (pointer: coarse) {
+    .touch-target {
+        position: relative;
+    }
+    .touch-target::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        min-width: 44px;
+        width: 100%;
+        height: 44px;
+        /* keep it strictly a hit surface — invisible, no paint */
+        pointer-events: auto;
+    }
 }
 
 /* Marquee — horizontal token scroll used on /skills hero */

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -375,7 +375,12 @@
   gap: 12px;
 }
 
-@media (min-width: 768px) {
+/* The footer's 2-col / right-aligned desktop layout is gated to the shell
+   release (821px) — NOT 768. At 768–820 the shell is already released into
+   mobile flow, and forcing the right-aligned now lane there spilled it past
+   the viewport (~33px horizontal overflow). Aligning to the 820 source of
+   truth keeps the centered single-column footer through the released band. */
+@media (min-width: 821px) {
   .footerGrid {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -391,7 +396,7 @@
   gap: 28px;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 821px) {
   .socials {
     justify-content: flex-start;
   }
@@ -454,7 +459,7 @@
   align-items: center;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 821px) {
   .nowLane {
     align-items: flex-end;
   }
@@ -510,7 +515,7 @@
   margin-top: 4px;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 821px) {
   .metaLine {
     justify-content: flex-end;
   }
@@ -543,6 +548,44 @@
 @media (max-width: 560px) {
   .titleLine {
     font-size: 2.75rem;
+  }
+}
+
+/* ── Touch UX (coarse pointers) ──────────────────────────────────────
+   Footer affordances are tuned for hover: the social icon links, the
+   "currently / now" link, the inline jarvis status, and the "ask jarvis"
+   CTA all have only ~8px hit padding (≈37px box), and the social arrow +
+   underlines reveal on hover (unreachable on touch). On a coarse pointer:
+   guarantee a >=44px tap target and surface the hover-revealed
+   affordances by default. Desktop (fine pointer / hover) is untouched. */
+@media (pointer: coarse) {
+  .social,
+  .nowLink,
+  .jarvisButton,
+  .jarvisStatus {
+    min-height: 44px;
+  }
+  /* Icon-only social rows (label hidden below 640px) need width too. */
+  .social {
+    min-width: 44px;
+    justify-content: center;
+  }
+  /* 5 × 44px targets + the 28px gaps overflow a ~325px-usable 360px phone.
+     Spread them edge-to-edge and trim the gap so every target stays >=44px
+     without horizontal overflow. The 821px desktop grid lane is unaffected
+     (this only applies below 640px, where the labels are hidden anyway). */
+  @media (max-width: 639px) {
+    .socials {
+      width: 100%;
+      justify-content: space-between;
+      gap: 0;
+    }
+  }
+  /* The arrow that slides in on hover — show it so the affordance reads
+     as tappable on touch. */
+  .socialArrow {
+    transform: translateX(0);
+    opacity: 1;
   }
 }
 

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -19,6 +19,7 @@ import {
   type NowStatus,
 } from "@/lib/content";
 import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
+import { useMobileFlow } from "@/hooks/useMobileFlow";
 
 // Presentation only — all /now data lives in src/lib/content.ts, where the
 // Building column is derived from `projects` (status === 'current') so the
@@ -231,6 +232,7 @@ export default function NowPage() {
 
 function NowContent() {
   const reduceMotion = usePrefersReducedMotion();
+  const isMobileFlow = useMobileFlow();
   const { onNavClick } = useShellNav();
 
   // ONE parallax instance, wired to the ScrollStage scroll container (the
@@ -239,6 +241,14 @@ function NowContent() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const { scrollY } = useScroll({ container: scrollRef });
   const parallaxY = useTransform(scrollY, [0, 500], [0, -60]);
+
+  // Below the 820px shell release the shell becomes height:auto and .scroll
+  // turns overflow:visible — the page scrolls on the window, NOT on scrollRef.
+  // The container-bound useScroll then never advances, but the y transform
+  // still offsets the hero, lifting "Currently" above the page (top:-1030px,
+  // unreachable). Disable parallax on mobile-flow (and reduced motion) so the
+  // hero is a plain in-flow first block that scrolls naturally.
+  const parallaxEnabled = !reduceMotion && !isMobileFlow;
 
   return (
     <ScrollStage ref={scrollRef}>
@@ -251,7 +261,7 @@ function NowContent() {
           style={{ maxWidth: "var(--measure-ledger)" }}
         >
           <motion.div
-            style={reduceMotion ? undefined : { y: parallaxY }}
+            style={parallaxEnabled ? { y: parallaxY } : undefined}
             className="will-change-transform w-full"
           >
             <Eyebrow
@@ -328,7 +338,10 @@ function NowContent() {
           className="mx-auto w-[90%]"
           style={{ maxWidth: "var(--measure-ledger)" }}
         >
-          <div className="grid items-start grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4 xl:gap-10">
+          {/* Breakpoints aligned to the 820px shell release: 1 col below 820
+              (mobile flow reads as a single column), 2 cols once the shell is
+              a fixed-height viewport again, 4 cols at xl (desktop unchanged). */}
+          <div className="grid items-start grid-cols-1 gap-12 min-[820px]:grid-cols-2 xl:grid-cols-4 xl:gap-10">
             {/* Column 1 — BUILDING (yellow) */}
             <Column
               index="01"

--- a/src/app/projetos/projects.module.css
+++ b/src/app/projetos/projects.module.css
@@ -35,7 +35,13 @@
 
 .heroGrid {
   display: grid;
-  grid-template-columns: minmax(390px, 0.9fr) minmax(460px, 1.1fr);
+  /* Softened track floors so the two-column band (1100–1280px, the only
+     viewport range where this grid is two-col) never demands more width than
+     the padded container can give — the old 390/460 floors summed to an 850px
+     hard min that overflowed near the 1100px boundary. At >=1280 the 0.9fr /
+     1.1fr ratios fully determine the column widths (both well above these
+     floors), so the desktop layout is byte-identical. */
+  grid-template-columns: minmax(320px, 0.9fr) minmax(380px, 1.1fr);
   align-items: center;
   gap: clamp(44px, 6vw, 90px);
   width: 100%;
@@ -667,7 +673,12 @@
     gap: 12px 16px;
   }
 
+  /* The index keeps the 54px column; meta, the description/dossier copy, and
+     tags all share the wide second column. Without pinning .ledgerCopy to
+     column 2 it auto-placed into the 54px index column and collapsed the
+     description to ~one word per line on tablet. */
   .ledgerMeta,
+  .ledgerCopy,
   .ledgerTags {
     grid-column: 2;
   }
@@ -718,6 +729,7 @@
   }
 
   .ledgerMeta,
+  .ledgerCopy,
   .ledgerTags {
     grid-column: auto;
   }

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import Mark from "@/components/ui/Mark";
 import PageNav from "@/components/ui/PageNav";
@@ -15,9 +15,21 @@ import ContentScrim from "@/components/layout/ContentScrim";
 import { skillCategories } from "@/lib/content";
 import { getColorValue, getColorWithAlpha } from "@/lib/colors";
 import { stagger, fadeUp, enterAt } from "@/lib/motion";
+import styles from "./skills.module.css";
 
 const BH_OFFSET_X = 200;
 const GRAVITY_SELECTOR = "[data-gravity-item]";
+
+/**
+ * The gravity rAF assumes a tall, wide desktop viewport: it warps every
+ * `data-gravity-item` toward the black-hole center at innerWidth/2 + offset,
+ * innerHeight/2. On the released mobile-flow shell (<=820px) and on short
+ * landscape viewports (the 1024×768 P0, where the black-hole center lands
+ * right on the reading column) that pull shoves the categories off-screen /
+ * out of reach. Disable the warp there so the text simply stacks and scrolls.
+ * Desktop (>=1280px, tall) keeps the signature pull untouched.
+ */
+const SHORT_VIEWPORT_QUERY = "(max-width: 820px), (max-height: 760px)";
 
 // Flat list of standout skill tokens for the hero marquee.
 const MARQUEE_TOKENS: string[] = skillCategories.flatMap((c) => c.skills);
@@ -74,6 +86,10 @@ function SkillsBackground() {
       {/* Black hole + DJ photo sit right-of-center; darken the left so the
           left-anchored text column stays legible over it. */}
       <ContentScrim side="left" intensity="strong" />
+      {/* Narrow-only: under the released shell the column re-centers over the
+          black hole — this route-local scrim recedes the bright DJ video so
+          the stacked category chips stay readable (no-op >=821px). */}
+      <div aria-hidden className={styles.legibility} />
     </>
   );
 }
@@ -82,16 +98,28 @@ function SkillsContent() {
   const { onNavClick } = useShellNav();
   const scrollRef = useRef<HTMLDivElement>(null);
   const reduceMotion = useReducedMotion();
+  // True when the released shell or a short landscape viewport is active —
+  // the gravity warp is disabled there so categories stack and scroll
+  // normally. SSR-safe (false on first paint, matching the desktop default).
+  const [warpDisabled, setWarpDisabled] = useState(false);
   const totalSkills = skillCategories.reduce(
     (acc, cat) => acc + cat.skills.length,
     0,
   );
 
   useEffect(() => {
+    const mql = window.matchMedia(SHORT_VIEWPORT_QUERY);
+    const update = () => setWarpDisabled(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
     const scrollEl = scrollRef.current;
     if (!scrollEl) return;
 
-    if (reduceMotion) {
+    if (reduceMotion || warpDisabled) {
       resetGravityStyles(scrollEl);
       return;
     }
@@ -161,14 +189,14 @@ function SkillsContent() {
       cancelAnimationFrame(frame);
       resetGravityStyles(scrollEl);
     };
-  }, [reduceMotion]);
+  }, [reduceMotion, warpDisabled]);
 
   return (
     <ScrollStage ref={scrollRef}>
       {/* Section 1 — Hero. Enters via the CSS `.enter-rise` idiom
           (globals.css), not framer `initial="hidden"` — the SSR HTML must
           paint the h1 before the pixi-heavy bundle hydrates (deep-link LCP). */}
-      <Section data-gravity-item align="left">
+      <Section data-gravity-item align="left" className={styles.section}>
         <div>
           <div className="enter-rise" style={enterAt(0)}>
             <Eyebrow index="03" label="what i do" />
@@ -284,7 +312,12 @@ function SkillsContent() {
           measure so even the widest chip row stays clear of the video circle
           (centered at innerWidth/2 + BH_OFFSET_X, ~160px radius) across
           1280–1920px. */}
-      <Section align="left" measure="narrow" innerClassName="!max-w-[520px]">
+      <Section
+        align="left"
+        measure="narrow"
+        innerClassName="!max-w-[520px]"
+        className={styles.section}
+      >
         <motion.div
           variants={stagger}
           initial="hidden"
@@ -330,7 +363,7 @@ function SkillsContent() {
       </Section>
 
       {/* Section 3 — Fun fact as pull-quote */}
-      <Section data-gravity-item align="left">
+      <Section data-gravity-item align="left" className={styles.section}>
         <motion.div
           initial="hidden"
           whileInView="show"

--- a/src/app/skills/skills.module.css
+++ b/src/app/skills/skills.module.css
@@ -1,0 +1,57 @@
+/* ──────────────────────────────────────────────────────────────────
+   /skills route-local overrides. Two concerns, both narrow/short only —
+   desktop (>=1280px, tall) is never touched by anything in this file.
+
+   1) SHORT-LANDSCAPE RELEASE (P0 @ 1024×768): above the 820px shell
+      release the shell is still a fixed-height snap box and each
+      .section is min-height:100% of a short viewport, so a category that
+      doesn't fit one snap page lands below the fold. The shell's inner
+      scroll already reaches every snap section — what made the stack read
+      as "unreachable" was the gravity warp dragging it off-screen, now
+      disabled in JS for this band (SHORT_VIEWPORT_QUERY). Here we only
+      shrink each section's vertical padding so a short snap page isn't
+      mostly empty air and the category content sits in view. We do NOT
+      release the inner scroll: the parent .shell stays height:100vh /
+      overflow:hidden in this band (shell.module.css, out of route scope),
+      so an auto-height inner scroll would be clipped, not scrollable.
+
+   2) NARROW LEGIBILITY (P1 @ 390/768): under the released shell the
+      black-hole DJ video sits behind the now-centered category column
+      and the bright chip rows wash out. A route-local scrim pushes the
+      reading column legible without dimming the cosmic identity.
+   ─────────────────────────────────────────────────────────────────── */
+
+/* 1 — short-landscape section padding. The 821–1280px band with a short
+   height keeps the shell's snap scroll (the inner .scroll already reaches
+   every section); we only tighten the section padding so the snap page is
+   not dominated by --section-pad-md whitespace at 768px tall. Doubled
+   class = higher specificity than shell.module.css's single .section so
+   this wins regardless of CSS-module bundle order. */
+@media (max-height: 760px) and (min-width: 821px) {
+  .section.section {
+    padding-block: var(--section-pad-sm);
+  }
+}
+
+/* 2 — narrow legibility scrim. Sits above the visual backdrop but below
+   the content, only below the 820px release where the column re-centers
+   over the black hole. Layers under ContentScrim's uniform dim for a bit
+   more contrast on the bright DJ video without hiding it. */
+.legibility {
+  display: none;
+}
+@media (max-width: 820px) {
+  .legibility {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: calc(var(--z-backdrop) + 2);
+    pointer-events: none;
+    background: radial-gradient(
+      120% 75% at 50% 42%,
+      rgba(5, 6, 10, 0.62) 0%,
+      rgba(5, 6, 10, 0.5) 45%,
+      rgba(5, 6, 10, 0.32) 100%
+    );
+  }
+}

--- a/src/components/chat/JarvisTrigger.tsx
+++ b/src/components/chat/JarvisTrigger.tsx
@@ -70,7 +70,7 @@ export default function JarvisTrigger({
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 1, delay: 1.2 }}
-      className="group/trigger fixed bottom-10 right-10 z-[60] flex flex-col items-end gap-1.5"
+      className="touch-target group/trigger fixed bottom-10 right-10 z-[60] flex flex-col items-end gap-1.5"
       style={{ fontFamily: 'var(--font-body)' }}
     >
       {/* Label row */}

--- a/src/components/layout/PageChrome.tsx
+++ b/src/components/layout/PageChrome.tsx
@@ -49,12 +49,49 @@ export default function PageChrome({
         }}
       />
 
+      {/* ── Mobile chrome (< 820px) ──────────────────────────────────────
+          Under the released auto-height shell the desktop absolute offsets
+          (top-[49px]/left-6/right-6/top-1/2) no longer track the viewport, so
+          below the shell's 820px release we render a compact fixed top bar
+          that DOES track the viewport: identity dot + wordmark + route label,
+          and a working back affordance on inner routes. The live HUD/clock +
+          vertical strip stay desktop-only (hidden here, P2). */}
+      <motion.div
+        variants={fadeIn}
+        initial="hidden"
+        animate="show"
+        className={shell.mobileChrome}
+      >
+        <div className={shell.mobileChromeBar}>
+          <div className={shell.mobileChromeIdent}>
+            <Identity status="rest" />
+            <div className={shell.mobileChromeWordmark}>
+              <span>Matheus · Kindrazki</span>
+              <span>
+                {label} · idx.{index}
+              </span>
+            </div>
+          </div>
+          {showBack && (
+            <Link
+              href="/"
+              onClick={onBackClick}
+              aria-label="Back to home"
+              className={shell.mobileChromeBack}
+            >
+              <span aria-hidden>&larr;</span>
+              <span>back</span>
+            </Link>
+          )}
+        </div>
+      </motion.div>
+
       {/* Top-left — Identity dots + wordmark (absolute to parent 1280px container) */}
       <motion.div
         variants={fadeIn}
         initial="hidden"
         animate="show"
-        className="absolute top-[49px] left-6 z-30 flex items-center gap-4"
+        className={`absolute top-[49px] left-6 z-30 flex items-center gap-4 ${shell.desktopChrome}`}
       >
         <Identity status="rest" />
         <div className={`hidden sm:flex flex-col ${shell.chromeWordmark}`}>
@@ -80,7 +117,7 @@ export default function PageChrome({
         variants={fadeIn}
         initial="hidden"
         animate="show"
-        className="absolute top-[49px] right-6 z-30 hidden sm:block text-right"
+        className={`absolute top-[49px] right-6 z-30 hidden sm:block text-right ${shell.desktopChrome}`}
       >
         <div className={shell.chromeHud}>
           <div className="flex items-center justify-end gap-2">
@@ -100,7 +137,7 @@ export default function PageChrome({
         variants={fadeIn}
         initial="hidden"
         animate="show"
-        className={`absolute right-5 top-1/2 z-30 hidden md:block pointer-events-none ${shell.chromeStrip}`}
+        className={`absolute right-5 top-1/2 z-30 hidden md:block pointer-events-none ${shell.chromeStrip} ${shell.desktopChrome}`}
         style={{
           writingMode: "vertical-rl",
           transform: "translateY(-50%) rotate(180deg)",

--- a/src/components/layout/shell.module.css
+++ b/src/components/layout/shell.module.css
@@ -106,6 +106,89 @@
   text-transform: uppercase;
 }
 
+/* ── Mobile chrome (< 820px) ───────────────────────────────────────
+   The desktop chrome blocks are positioned with absolute offsets against
+   the (desktop) fixed-height shell. Below the 820px release the shell is
+   height:auto, so those offsets stop tracking the viewport — we hide them
+   (.desktopChrome) and render a compact FIXED top bar (.mobileChrome) that
+   tracks the viewport on its own: wordmark/identity + a working back link.
+   The live HUD/clock + vertical strip remain desktop-only (P2). */
+.mobileChrome {
+  display: none;
+}
+@media (max-width: 820px) {
+  .desktopChrome {
+    display: none !important;
+  }
+  .mobileChrome {
+    display: block;
+    position: fixed;
+    inset: 0 0 auto 0;
+    z-index: var(--z-chrome);
+    padding: calc(env(safe-area-inset-top, 0px) + 0.625rem)
+      max(env(safe-area-inset-right, 0px), 1rem) 0.625rem
+      max(env(safe-area-inset-left, 0px), 1rem);
+    /* Keep the wordmark legible over the cosmic background without hiding it. */
+    background: linear-gradient(
+      to bottom,
+      rgba(5, 6, 10, 0.78) 0%,
+      rgba(5, 6, 10, 0.5) 60%,
+      rgba(5, 6, 10, 0) 100%
+    );
+    backdrop-filter: blur(3px);
+    pointer-events: none;
+  }
+  .mobileChromeBar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+  .mobileChromeIdent {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+  .mobileChromeWordmark {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    color: var(--color-kindra-meta-low);
+    font-family: var(--font-data);
+    font-size: var(--text-micro);
+    font-variant-numeric: tabular-nums;
+    line-height: 1.45;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+  .mobileChromeWordmark span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* Back affordance — a real >=44px tap target, visible (not hover-only). */
+  .mobileChromeBack {
+    pointer-events: auto;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 44px;
+    padding: 0 0.75rem;
+    color: rgba(255, 255, 255, 0.78);
+    font-family: var(--font-data);
+    font-size: var(--text-data);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    transition: color 0.4s ease;
+  }
+  .mobileChromeBack:active {
+    color: #fff;
+  }
+}
+
 /* ── Mobile / narrow fallback ──────────────────────────────────────
    Below 820px: stop trapping the user in a 100vh snap box. Let the
    shell grow with content and disable mandatory snap so every section
@@ -117,6 +200,10 @@
     min-height: 100svh;
     max-height: none;
     overflow: visible;
+    /* Clear the fixed mobile chrome bar (.mobileChrome) so the first in-flow
+       content block (e.g. /now hero, /contato h1) is not tucked under it.
+       ~44px back-button row + vertical padding + the notch safe-area. */
+    padding-top: calc(env(safe-area-inset-top, 0px) + 4rem);
   }
   .scroll {
     height: auto;

--- a/src/components/ui/ContactForm.tsx
+++ b/src/components/ui/ContactForm.tsx
@@ -33,9 +33,17 @@ function FloatingField({ id, label, type = 'text', name, required, rows = 4 }: F
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
       setHasValue(e.target.value.length > 0),
     className:
-      'peer w-full bg-transparent text-[var(--color-kindra-text-white)] text-[14px] leading-[22px] pt-5 pb-2 outline-none resize-none',
+      'peer w-full bg-transparent text-[var(--color-kindra-text-white)] text-[14px] leading-[22px] outline-none resize-none',
+    // Vertical padding via inline style, not Tailwind: globals.css has an
+    // unlayered `* { padding: 0 }` reset that beats @layer utilities, so
+    // `pt-5 pb-2` would render as 0 (collapsing the field under the floating
+    // label). Inline styles are unlayered too → they win. The 20px top pad
+    // also makes room for the floated label (top:0, ~9.5px) above the text,
+    // and keeps single-line inputs at a >=44px tap target (20+22+8).
     style: {
       fontFamily: 'var(--font-body)',
+      paddingTop: '20px',
+      paddingBottom: '8px',
     } as React.CSSProperties,
   }
 
@@ -137,7 +145,7 @@ export default function ContactForm() {
       <button
         type="submit"
         disabled={status === 'sending'}
-        className="group/submit relative mt-2 inline-flex w-fit items-center gap-2 text-[12px] font-bold uppercase tracking-[0.28em] transition-all duration-700"
+        className="touch-target group/submit relative mt-2 inline-flex w-fit items-center gap-2 text-[12px] font-bold uppercase tracking-[0.28em] transition-all duration-700"
         style={{
           color: status === 'sent' ? green : red,
           transitionTimingFunction: 'cubic-bezier(0.19, 1, 0.22, 1)',

--- a/src/components/ui/PageNav.tsx
+++ b/src/components/ui/PageNav.tsx
@@ -54,6 +54,7 @@ export default function PageNav({ current, onClick }: PageNavProps) {
             href={link.href}
             color={link.color}
             onClick={onClick?.(link.href)}
+            className="touch-target"
           >
             {link.label}
           </AnimatedLink>

--- a/src/hooks/useMobileFlow.ts
+++ b/src/hooks/useMobileFlow.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Canonical "mobile-flow" signal — the JS twin of the shell's CSS release.
+ *
+ * shell.module.css releases the fixed-height snap viewport at `max-width:
+ * 820px` (the shell becomes height:auto, snap is disabled, sections flow in
+ * natural height). Routes that drive their own layout in JS — parallax via
+ * useScroll, a scroll-jacking rAF (skills' gravity field), or a forced
+ * fixed-height/!scroll wrapper — must DISABLE that logic when the shell is
+ * released, or they fight it and push content off-screen (the /now, /skills,
+ * /contato P0s).
+ *
+ * This hook returns `true` exactly when that CSS release is active, so route
+ * code can gate the desktop-only behavior on `!isMobileFlow`. It is:
+ *  - width-based only (mirrors the CSS media query precisely — NOT touch- or
+ *    UA-based, so a desktop with a touchscreen or a >820px landscape tablet
+ *    stays on the desktop path);
+ *  - SSR-safe (returns `false` until mounted, matching the desktop-first CSS
+ *    default before the media query applies);
+ *  - resize-reactive via matchMedia.
+ *
+ * The breakpoint is exported so it stays the single source of truth shared
+ * with the CSS (keep them in lockstep).
+ */
+export const MOBILE_FLOW_MAX_WIDTH = 820;
+
+const QUERY = `(max-width: ${MOBILE_FLOW_MAX_WIDTH}px)`;
+
+export function useMobileFlow(): boolean {
+  const [isMobileFlow, setIsMobileFlow] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(QUERY);
+    const update = () => setIsMobileFlow(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return isMobileFlow;
+}
+
+export default useMobileFlow;

--- a/src/pixi/layers/PortraitParticlesLayer.ts
+++ b/src/pixi/layers/PortraitParticlesLayer.ts
@@ -43,6 +43,18 @@ import {
 
 /** Per-particle assembly stagger (fraction of the progress range). */
 const ASSEMBLY_STAGGER = 0.18;
+/**
+ * Responsive portrait offset contract. The per-page `xOffset` (250 home /
+ * 330 sobre) is baked into each seed's relX so the cloud sits right-of-center
+ * on the desktop spread. On narrow viewports that pushes the face off the
+ * right edge, so the layer cancels a fraction of the baked offset at runtime
+ * by shifting the draw center left — desktop (>= this width) keeps the full
+ * offset, the release point zeroes it so the portrait centers behind the
+ * now-centered text, and it lerps linearly between.
+ */
+const PORTRAIT_OFFSET_FULL_W = 1280;
+/** Matches the shell's 820px mobile-flow release: at/below this the offset is 0. */
+const PORTRAIT_OFFSET_ZERO_W = 820;
 /** Hard cap for the CPU fallback path — the GPU path has no such limit. */
 const CPU_FALLBACK_MAX_PARTICLES = 30000;
 const MOUSE_RADIUS = 130;
@@ -445,6 +457,31 @@ export class PortraitParticlesLayer implements PixiLayer {
     this.buildCpu(this.seeds, divisor);
   }
 
+  /**
+   * Live draw-center X, with the responsive portrait offset applied. The full
+   * per-page xOffset is baked into the seeds (relX) and drawn relative to
+   * width/2; on narrow viewports we cancel a fraction of it by shifting the
+   * center left so the face is not pushed off the right edge. Desktop
+   * (>= PORTRAIT_OFFSET_FULL_W) is unchanged; at/below PORTRAIT_OFFSET_ZERO_W
+   * the portrait centers behind the (now-centered) text.
+   */
+  private centerX(): number {
+    const cx = this.width / 2;
+    const baked = this.config?.xOffset ?? 250;
+    if (baked === 0 || typeof window === "undefined") return cx;
+    const vw = window.innerWidth || this.width;
+    let offsetScale: number;
+    if (vw >= PORTRAIT_OFFSET_FULL_W) offsetScale = 1;
+    else if (vw <= PORTRAIT_OFFSET_ZERO_W) offsetScale = 0;
+    else {
+      offsetScale =
+        (vw - PORTRAIT_OFFSET_ZERO_W) /
+        (PORTRAIT_OFFSET_FULL_W - PORTRAIT_OFFSET_ZERO_W);
+    }
+    // Cancel the un-wanted portion of the baked offset.
+    return cx - baked * (1 - offsetScale);
+  }
+
   /** Halve density on small viewports and again on very dense displays. */
   private environmentDivisor(): number {
     if (typeof window === "undefined") return 1;
@@ -582,7 +619,7 @@ export class PortraitParticlesLayer implements PixiLayer {
    */
   private updateGpuUniforms(): void {
     if (!this.uniforms || !this.config) return;
-    const cx = this.width / 2;
+    const cx = this.centerX();
     const cy = this.height / 2;
     const pointSize = this.config.particleSize ?? 1.8;
     const uploaded = this.uploaded;
@@ -638,7 +675,7 @@ export class PortraitParticlesLayer implements PixiLayer {
   private updateCpuParticles(): void {
     if (!this.config) return;
     const t = easeInOutCubic(clamp(this.progress));
-    const cx = this.width / 2;
+    const cx = this.centerX();
     const cy = this.height / 2;
     const size = this.config.particleSize ?? 1.8;
     const baseScale = size / 32;


### PR DESCRIPTION
Versão responsiva de verdade — partindo de uma auditoria com browser headless real em 390/768/1024px que mapeou o que estava quebrado. **Desktop (≥1280px) fica idêntico.**

## P0 corrigidos (conteúdo estava inacessível no mobile)
- **/now**: o hero 'Currently' renderizava em `top:-1030px` (parallax preso à altura fixa) — inalcançável. Agora flui normal abaixo de 820px.
- **/contato**: conteúdo (1107px) cortado num viewport de 844px que não rolava → agora rola e tudo é alcançável.
- **/skills**: categorias inalcançáveis em telas baixas + colidindo com o black hole → coluna única legível, visual recua sob o scrim.

## P1 corrigidos
- Retrato de partículas: `xOffset` escala por viewport (centra atrás do texto no mobile, em vez de jogar o rosto pra fora).
- /projetos: coluna de descrição de 54px no tablet + overflow na banda 900-1100px.
- Home: overflow horizontal de 33px no footer a 768px.

## Fundação + Touch UX
- Chrome mobile compacto (wordmark + back), hook `useMobileFlow` (820px = fonte de verdade).
- Tap targets ≥44px; affordances hover-reveal agora aparecem no touch.

## Verificação (Chrome headless real, não a aba MCP)
**0 overflow horizontal nas 6 rotas a 390px**; todo conteúdo antes cortado agora alcançável; rosto on-screen; top bar com wordmark+back. `tsc` limpo, `next build` 0/0 (22 rotas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Otimizado layout responsivo para telas com até 820px de largura.
  * Expandidas áreas de toque em botões e links para melhor usabilidade em dispositivos móveis.
  * Adicionada barra de navegação fixa no topo em viewports menores.
  * Ajustados espaçamentos e alinhamentos em seções e grids em telas pequenas.

* **Refactor**
  * Desabilitado efeito parallax em viewport pequeno e com movimento reduzido.
  * Melhorado posicionamento de elementos para melhor visibilidade em telas estreitas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->