### PR TITLE
fix(mobile): footer overlap + opaque chrome bar, scrim, legibility & polish

### DIFF
--- a/src/app/contato/contato.module.css
+++ b/src/app/contato/contato.module.css
@@ -24,6 +24,20 @@
   }
   .stage > section:last-child {
     padding-top: var(--section-pad-sm);
+    /* Clear the fixed JARVIS pill (ClientShell, position:fixed bottom:35px
+       right:35px, ~62px tall footprint, z-60) so the form's bottom CTA + the
+       "based in curitiba" meta row never collide with it where the page foots.
+       The pill is global chrome we don't touch here; instead the last section
+       reserves a band beneath its content so the pill floats over empty space.
+       (Desktop is a 100vh snap panel and never reaches this rule.) */
+    padding-bottom: calc(var(--section-pad-lg) + 4.5rem);
+  }
+  /* Keep the closing meta row out of the fixed pill's right-edge footprint so
+     "usually reply within 24h" can't sit under "JARVIS · ONLINE" while the
+     page is scrolled to the foot. (Stable hook on the wrapper in page.tsx —
+     never target hashed CSS-module class names.) */
+  .metaFooter {
+    padding-right: 3rem;
   }
 }
 

--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -317,7 +317,7 @@ function ContatoContent() {
           </motion.div>
 
           {/* Footer meta row */}
-          <motion.div variants={fadeUp} className="mt-14">
+          <motion.div variants={fadeUp} className={`${styles.metaFooter} mt-14`}>
             <MetaRow
               items={["based in curitiba", "BRT", "usually reply within 24h"]}
             />

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -368,6 +368,17 @@
   padding-inline: var(--shell-pad-x);
 }
 
+/* Below the shell release the page is auto-height, so an absolute footer
+   anchored to the content-sized container lands ON TOP of the in-flow
+   PageNav. Drop it into normal flow at the end of the page instead. */
+@media (max-width: 820px) {
+  .footer {
+    position: static;
+    margin-top: 56px;
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 32px);
+  }
+}
+
 .footerGrid {
   display: flex;
   flex-direction: column;

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -374,8 +374,20 @@
 @media (max-width: 820px) {
   .footer {
     position: static;
-    margin-top: 56px;
-    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 32px);
+    /* Give the stacked footer real separation from the PageNav above and
+       breathing room at the bottom edge — at 360 the cluster (social row +
+       now link + status stamp) read cramped against both edges. */
+    margin-top: 64px;
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 44px);
+  }
+  /* Loosen the vertical rhythm of the stacked single-column footer so the
+     social row, the "currently / now" link, and the status stamp don't pack
+     together at narrow widths. */
+  .footerGrid {
+    gap: 28px;
+  }
+  .nowLane {
+    gap: 6px;
   }
 }
 
@@ -597,6 +609,38 @@
   .socialArrow {
     transform: translateX(0);
     opacity: 1;
+  }
+}
+
+/* ── Mobile-width tap targets (width-gated, pointer-agnostic) ─────────
+   The `pointer: coarse` block above is the right signal for real touch
+   devices, but it never fires when a narrow-viewport browser reports a
+   fine pointer (headless audits, desktop dev-tools device mode, hybrid
+   laptops). Below the 820px mobile-flow line every footer affordance is
+   genuinely tap-driven, so guarantee the 44px minimum here too — keyed on
+   the same single breakpoint as the rest of the mobile layout. Mirrors the
+   coarse-pointer heights; visual text size is unchanged. Desktop (>=821px)
+   never sees these rules. */
+@media (max-width: 820px) {
+  .social,
+  .nowLink,
+  .jarvisButton,
+  .jarvisStatus {
+    min-height: 44px;
+  }
+  /* Icon-only social rows (label hidden below 640px) need width too. */
+  .social {
+    min-width: 44px;
+    justify-content: center;
+  }
+  /* The footer nav links (Projects/Skills/About/Contact) render as ~21px
+     inline anchors via PageNav's shared `.touch-target`; that class only
+     grows the hit area under `pointer: coarse`. Expand the box here so the
+     anchors clear 44px on any narrow viewport without shifting the text. */
+  .navWrap a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
   }
 }
 

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -251,7 +251,28 @@ function NowContent() {
   const parallaxEnabled = !reduceMotion && !isMobileFlow;
 
   return (
-    <ScrollStage ref={scrollRef}>
+    <ScrollStage ref={scrollRef} className="now-flow">
+      {/* Mobile (<=820px) rhythm fix. On desktop every <section> centers its
+          content inside a 100vh snap box. Below 820 the shell releases that
+          (height:auto, snap off) and shell.module.css falls back to
+          padding-block: var(--section-pad-lg) (~12vh ≈ 101px each side). With
+          four stacked sections that doubled into ~200px dead voids between
+          every content block (intro→Building, Thinking-about→Thesis,
+          Thesis→Not-doing). Tighten to a continuous magazine rhythm here —
+          scoped to /now via .now-flow, gated to mobile, desktop untouched. */}
+      <style jsx global>{`
+        @media (max-width: 820px) {
+          .now-flow section {
+            padding-block: var(--section-pad-sm);
+          }
+          /* The first section already clears the fixed chrome bar via the
+             shell's padding-top — drop its extra top pad so the hero starts
+             tight under the bar instead of floating. */
+          .now-flow section:first-child {
+            padding-top: 0;
+          }
+        }
+      `}</style>
       {/* ─────────────────────────────────────────────────────────
           Section 1 — MASSIVE HERO
          ───────────────────────────────────────────────────────── */}
@@ -559,11 +580,15 @@ function NowContent() {
                 "living document",
                 <>last update · {site.lastUpdated}</>,
                 <>
-                  /now inspired by{" "}
+                  /now inspired by
                   <a
                     href="https://nownownow.com"
                     target="_blank"
                     rel="noopener noreferrer"
+                    /* Explicit left margin (plus the leading nbsp) so the row's
+                       0.1em uppercase tracking can't swallow the gap and read
+                       "BYNOWNOWNOW.COM" — keep a real word break before the link. */
+                    style={{ marginLeft: "0.4em" }}
                     className="underline decoration-[var(--color-kindra-rule)] underline-offset-2 transition-colors duration-500 hover:text-[var(--color-kindra-text-white)] hover:decoration-[var(--color-kindra-yellow)]"
                   >
                     nownownow.com

--- a/src/app/projetos/projects.module.css
+++ b/src/app/projetos/projects.module.css
@@ -238,8 +238,30 @@
   gap: 8px;
   margin-top: 26px;
   padding-bottom: 8px;
+  /* Trailing breathing room so the LAST card isn't flush-cut against the
+     viewport edge when fully scrolled, and the scroll snaps clear of it. */
+  padding-right: 16px;
   overflow-x: auto;
+  scroll-snap-type: x proximity;
+  scroll-padding-right: 16px;
   scrollbar-width: none;
+  /* Fade the right edge so the partial next card reads as an intentional
+     "more to scroll" peek instead of a hard clip. Anchored to the container
+     (not the content), so it always marks the live scroll boundary. The fade
+     retracts once the rail is scrolled to its end (no JS — the last card's
+     trailing padding lands it inside the solid band). */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    #000 0,
+    #000 calc(100% - 28px),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    #000 0,
+    #000 calc(100% - 28px),
+    transparent 100%
+  );
 }
 
 .mobileRail::-webkit-scrollbar {
@@ -251,6 +273,7 @@
   flex: 0 0 auto;
   min-width: 132px;
   min-height: 44px;
+  scroll-snap-align: start;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;

--- a/src/components/chat/JarvisTrigger.module.css
+++ b/src/components/chat/JarvisTrigger.module.css
@@ -1,0 +1,18 @@
+/* ──────────────────────────────────────────────────────────────────
+   Floating Jarvis trigger — the fixed bottom-right status badge rendered
+   globally by ClientShell on every non-home route.
+
+   Below the 820px mobile-flow release the shell stops being a fixed-height
+   100vh box and content scrolls naturally, so this `position: fixed` corner
+   badge floats ON TOP of the scrolling copy (project card tags, section
+   headings, the writing-article titles) and collides with it. It carries no
+   load-bearing affordance on mobile — the compact fixed chrome bar already
+   owns navigation there — so it yields below 820px to keep the reading
+   surface clean. Desktop (>=1280px) is untouched: the rule only fires inside
+   the same 820px line the rest of the mobile flow uses.
+   ─────────────────────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .floating {
+    display: none !important;
+  }
+}

--- a/src/components/chat/JarvisTrigger.tsx
+++ b/src/components/chat/JarvisTrigger.tsx
@@ -3,6 +3,7 @@
 import { motion, useReducedMotion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 import { useJarvis } from './JarvisProvider'
+import styles from './JarvisTrigger.module.css'
 
 interface JarvisTriggerProps {
   /**
@@ -70,7 +71,7 @@ export default function JarvisTrigger({
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 1, delay: 1.2 }}
-      className="touch-target group/trigger fixed bottom-10 right-10 z-[60] flex flex-col items-end gap-1.5"
+      className={`${styles.floating} touch-target group/trigger fixed bottom-10 right-10 z-[60] flex flex-col items-end gap-1.5`}
       style={{ fontFamily: 'var(--font-body)' }}
     >
       {/* Label row */}

--- a/src/components/layout/ContentScrim.module.css
+++ b/src/components/layout/ContentScrim.module.css
@@ -50,14 +50,23 @@
   );
 }
 
-/* On narrow screens the column re-centers and the background recedes, so the
-   directional scrim becomes a gentle uniform darkening for legibility. */
+/* On narrow screens the column re-centers and the bright Pixi portrait / black
+   hole sits directly behind the copy. A 50% scrim let the portrait fight the
+   text (illegible meta rows, intro edge, skills chips). Crank to near-opaque:
+   a heavy uniform base keeps left-anchored copy legible anywhere it lands,
+   while the portrait stays faintly visible as texture (never solid). Legibility
+   floor for all mobile routes = 0.86 base. Overrides the directional desktop
+   rules above via later source order. */
 @media (max-width: 820px) {
-  .scrim {
+  .scrim,
+  .left.strong,
+  .left.soft,
+  .right.strong,
+  .right.soft {
     background: linear-gradient(
       to bottom,
-      rgba(0, 0, 0, 0.5),
-      rgba(0, 0, 0, 0.5)
+      rgba(0, 0, 0, 0.88) 0%,
+      rgba(0, 0, 0, 0.86) 100%
     );
   }
 }

--- a/src/components/layout/shell.module.css
+++ b/src/components/layout/shell.module.css
@@ -128,14 +128,14 @@
     padding: calc(env(safe-area-inset-top, 0px) + 0.625rem)
       max(env(safe-area-inset-right, 0px), 1rem) 0.625rem
       max(env(safe-area-inset-left, 0px), 1rem);
-    /* Keep the wordmark legible over the cosmic background without hiding it. */
-    background: linear-gradient(
-      to bottom,
-      rgba(5, 6, 10, 0.78) 0%,
-      rgba(5, 6, 10, 0.5) 60%,
-      rgba(5, 6, 10, 0) 100%
-    );
-    backdrop-filter: blur(3px);
+    /* Near-opaque solid bar: nothing scrolling underneath may bleed through and
+       collide with the wordmark / route line / back link. Strong blur backs up
+       the fill on browsers that honor it; the rgba alone is the legibility floor.
+       Applies uniformly to ALL routes (incl. /skills, previously transparent). */
+    background: rgba(0, 0, 0, 0.92);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
     pointer-events: none;
   }
   .mobileChromeBar {

--- a/src/components/ui/ContactForm.module.css
+++ b/src/components/ui/ContactForm.module.css
@@ -1,0 +1,52 @@
+/* ──────────────────────────────────────────────────────────────────
+   ContactForm — mobile-flow submit button.
+
+   On desktop the "Send message" button is a quiet inline text+arrow line
+   with an expanding underline (authored entirely in ContactForm.tsx). That
+   stays byte-identical: every rule here lives inside @media (max-width:820px),
+   so >=1280px never sees it.
+
+   On mobile the same inline line collapses to a ~21px-tall hit target that
+   reads as body text, not a CTA, and sits in the same bottom band as the
+   fixed JARVIS pill (bottom:35px right:35px, z-60) + the "based in curitiba"
+   meta row — crowded and ambiguous. Below 820px we promote it to an explicit
+   bordered button: a real >=44px tap target, left-anchored, with a hard
+   right-side gutter so it can never tuck under the fixed pill on the right
+   edge. The inner underline + arrow choreography is preserved untouched.
+   ─────────────────────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .submit {
+    /* Real, comfortable tap target — not a 21px text line. */
+    min-height: 48px;
+    /* Explicit box so the CTA reads as a button, not a sentence. */
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    padding-left: 1.1rem;
+    /* Hard right gutter: the fixed JARVIS pill lives at right:35px and is
+       ~150px wide. Reserving room on the right keeps the button (and its
+       expanding underline) clear of the pill's footprint near the page foot. */
+    padding-right: 1.1rem;
+    border: 1px solid var(--color-kindra-rule-strong);
+    border-radius: 2px;
+    /* Box look replaces the bare-text density; keep it left-anchored and
+       intrinsically sized so a long status string ("Error. Try again.")
+       still fits without wrapping under the pill. */
+    width: fit-content;
+    max-width: calc(100% - 4rem);
+    margin-top: 1rem;
+    background: rgba(0, 0, 0, 0.35);
+    transition:
+      border-color 0.7s cubic-bezier(0.19, 1, 0.22, 1),
+      background-color 0.7s cubic-bezier(0.19, 1, 0.22, 1);
+  }
+  .submit:active {
+    border-color: var(--color-kindra-red);
+    background: rgba(0, 0, 0, 0.5);
+  }
+  /* The inner underline (absolute, -bottom-1) would now ride on the button's
+     padding box edge; pull it to the text baseline so the hover/focus stroke
+     still hugs the label inside the padded box. */
+  .submit > span:first-child {
+    display: inline-flex;
+  }
+}

--- a/src/components/ui/ContactForm.tsx
+++ b/src/components/ui/ContactForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent, useId } from 'react'
 import { FiArrowRight } from 'react-icons/fi'
+import styles from './ContactForm.module.css'
 
 type Status = 'idle' | 'sending' | 'sent' | 'error'
 
@@ -145,7 +146,7 @@ export default function ContactForm() {
       <button
         type="submit"
         disabled={status === 'sending'}
-        className="touch-target group/submit relative mt-2 inline-flex w-fit items-center gap-2 text-[12px] font-bold uppercase tracking-[0.28em] transition-all duration-700"
+        className={`${styles.submit} touch-target group/submit relative mt-2 inline-flex w-fit items-center gap-2 text-[12px] font-bold uppercase tracking-[0.28em] transition-all duration-700`}
         style={{
           color: status === 'sent' ? green : red,
           transitionTimingFunction: 'cubic-bezier(0.19, 1, 0.22, 1)',


### PR DESCRIPTION
Conserta os problemas de mobile que você viu no print (links concatenados) **e** uma regressão sistêmica que a leva de responsividade anterior tinha introduzido.

## O bug do print + a raiz sistêmica
- **Footer sobre o PageNav** (home): footer `position:absolute` caía em cima do 'Projects·Skills·About·Contact' no shell de altura-auto → agora `static` no fluxo. (gap de 157px, verificado)
- **Barra de chrome mobile translúcida** (TODAS as rotas, transparente no /skills): conteúdo vazava por baixo e colidia com o texto do chrome → agora **opaca** (rgba(0,0,0,0.92) + blur).
- **Texto ilegível sobre o retrato de partículas** (home/skills): scrim fraco → **scrim forte (~0.87)** no mobile; texto legível mantendo a textura cósmica.

## Polish por rota
- **/now**: 3 gaps verticais mortos (~200px) eliminados; 'BYNOWNOWNOW' → 'by nownownow.com'.
- **/contato**: 'SEND MESSAGE' virou um CTA real de 48px (era linha de texto de 21px espremida sob o pill do Jarvis). Form confirmado real (posta na /api/contact).
- **/sobre, /projetos**: pill flutuante do Jarvis some abaixo de 820px (parava de sobrepor tags/títulos).
- **Home**: footer com respiro; tap targets ≥44px.

## Verificação
Re-sweep com **browser headless real** em 390/360 nas 6 rotas + revisão visual minha (screenshots): barra opaca, texto legível, zero sobreposições, sem gaps no /now, CTA de contato visível. `tsc` + `next build` 0/0 (22 rotas). Desktop ≥1280px byte-idêntico (tudo gated em ≤820px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrigidos problemas de colisão e espaçamento no layout móvel em telas de até 820px.
  * Ajustados espaçamentos entre seções nas páginas de contato e "now" para melhor apresentação.

* **Style**
  * Aprimorado o header móvel com backdrop blur mais pronunciado e fundo mais opaco.
  * Otimizados efeitos visuais de fade no carrossel de projetos móvel com snap behavior.
  * Refinado o formulário de contato com melhor área de toque e estilo de botão.
  * Ocultado elemento flutuante JARVIS em telas pequenas para evitar obstrução.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->