### PR TITLE
security: disconnect public chat from the personal Jarvis backend

### DIFF
--- a/src/app/api/ask/route.ts
+++ b/src/app/api/ask/route.ts
@@ -1,25 +1,48 @@
-// TODO: add IP-based rate limiting before public deployment
-
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
+/**
+ * SECURITY — the public portfolio chat is DISCONNECTED from the personal
+ * Jarvis backend.
+ *
+ * The previous implementation proxied every anonymous visitor message straight
+ * to the owner's personal Jarvis (`platform: 'api'`), which the backend treats
+ * as the owner: full access to private context (profile, agenda, memory,
+ * documents) AND the ability to EXECUTE actions (it was observed creating
+ * tasks). That leaks personal data and lets strangers mutate the owner's
+ * system — unacceptable for a public endpoint.
+ *
+ * Until the Jarvis backend ships a hardened public/read-only mode (no personal
+ * data, no actions), this route does NOT call Jarvis at all. It returns a
+ * fixed, safe message. The proxy stays gated behind an explicit opt-in env so
+ * it can never silently re-enable: it only proxies when
+ * JARVIS_PUBLIC_MODE === 'enabled' AND the URL/key are set. Setting the key
+ * alone is no longer enough.
+ */
+
 const JARVIS_URL = process.env.JARVIS_API_URL
 const JARVIS_KEY = process.env.JARVIS_API_KEY
+const PUBLIC_MODE_ENABLED = process.env.JARVIS_PUBLIC_MODE === 'enabled'
+
+const UNAVAILABLE_MESSAGE =
+  "Jarvis is offline for visitors right now — it's my private assistant, not a public one. " +
+  'Ask me anything in person instead: reach me through the contact page.'
+
+function unavailable(): Response {
+  return Response.json(
+    {
+      response: UNAVAILABLE_MESSAGE,
+      sources: [],
+      suggested_buttons: [],
+      conversation_id: null,
+    },
+    { status: 200 },
+  )
+}
 
 export async function POST(req: Request): Promise<Response> {
-  if (!JARVIS_URL || !JARVIS_KEY) {
-    return Response.json(
-      {
-        response:
-          "Jarvis is sleeping — the portfolio owner hasn't wired up the API key yet. But he's real, and you can reach him via the contact page.",
-        sources: [],
-        suggested_buttons: [],
-        conversation_id: null,
-      },
-      { status: 200 },
-    )
-  }
-
+  // Validate input shape even while disabled, so the contract is stable and we
+  // never echo arbitrary bodies back.
   let body: { message?: string; conversation_id?: string | null }
   try {
     body = (await req.json()) as {
@@ -41,6 +64,17 @@ export async function POST(req: Request): Promise<Response> {
     )
   }
 
+  // Hard gate: the personal Jarvis is NEVER contacted unless public mode is
+  // explicitly enabled AND the backend has a hardened read-only public mode.
+  // Today that mode does not exist, so this stays off and we short-circuit.
+  if (!PUBLIC_MODE_ENABLED || !JARVIS_URL || !JARVIS_KEY) {
+    return unavailable()
+  }
+
+  // NOTE: This proxy path is intentionally unreachable until JARVIS_PUBLIC_MODE
+  // is set to 'enabled'. Before enabling it, the Jarvis backend MUST enforce a
+  // public, read-only, no-actions, no-personal-data mode for `platform:
+  // 'public'`. Do not flip the env without that guarantee.
   try {
     const upstream = await fetch(`${JARVIS_URL}/chat`, {
       method: 'POST',
@@ -51,24 +85,16 @@ export async function POST(req: Request): Promise<Response> {
       body: JSON.stringify({
         message,
         conversation_id: body.conversation_id ?? undefined,
-        platform: 'api',
+        // Signal the public, consultative, read-only context to the backend.
+        // The backend is the source of truth for enforcing it.
+        platform: 'public',
+        mode: 'public_readonly',
+        allow_actions: false,
       }),
-      // Jarvis responses can take 15s+ for complex questions. Set a 45s server timeout.
       signal: AbortSignal.timeout(45_000),
     })
 
-    if (!upstream.ok) {
-      return Response.json(
-        {
-          response:
-            'Jarvis had trouble answering that one. Try rephrasing, or reach Matheus directly at matheus@kindrazki.dev.',
-          sources: [],
-          suggested_buttons: [],
-          conversation_id: body.conversation_id ?? null,
-        },
-        { status: 200 },
-      )
-    }
+    if (!upstream.ok) return unavailable()
 
     const data = (await upstream.json()) as {
       response?: unknown
@@ -77,7 +103,6 @@ export async function POST(req: Request): Promise<Response> {
       conversation_id?: unknown
     }
 
-    // Pass through only the fields the UI uses — don't leak upstream internals
     return Response.json({
       response: typeof data.response === 'string' ? data.response : '',
       sources: Array.isArray(data.sources) ? data.sources : [],
@@ -87,19 +112,7 @@ export async function POST(req: Request): Promise<Response> {
       conversation_id:
         typeof data.conversation_id === 'string' ? data.conversation_id : null,
     })
-  } catch (err) {
-    const msg =
-      err instanceof Error && err.name === 'TimeoutError'
-        ? 'Jarvis took too long to reply — try a simpler question.'
-        : 'Jarvis hit a snag. Try again in a moment.'
-    return Response.json(
-      {
-        response: msg,
-        sources: [],
-        suggested_buttons: [],
-        conversation_id: body.conversation_id ?? null,
-      },
-      { status: 200 },
-    )
+  } catch {
+    return unavailable()
   }
 }

--- a/src/components/chat/JarvisChat.tsx
+++ b/src/components/chat/JarvisChat.tsx
@@ -20,12 +20,10 @@ import {
 } from '@/hooks/useJarvisChat'
 import styles from './JarvisChat.module.css'
 
-const SUGGESTIONS: string[] = [
-  "what's matheus building right now?",
-  'tell me about MokLabs',
-  "what's his engineering philosophy?",
-  'why Jarvis?',
-]
+// Jarvis is offline for visitors (it's the owner's private assistant — see
+// /api/ask). No starter prompts, since nothing will be answered. Restore these
+// only once a hardened public read-only mode exists.
+const SUGGESTIONS: string[] = []
 
 function useIsNarrow(breakpoint = 640): boolean {
   const [narrow, setNarrow] = useState(false)
@@ -237,6 +235,7 @@ export default function JarvisChat() {
 
   const showSuggestions = useMemo(() => {
     return (
+      SUGGESTIONS.length > 0 &&
       messages.length === 1 &&
       messages[0].role === 'assistant' &&
       messages[0].content === JARVIS_INTRO
@@ -306,11 +305,11 @@ export default function JarvisChat() {
                     className={`${styles.statusRow} flex items-center gap-2 text-[10px] uppercase tracking-[0.3em] text-[var(--color-kindra-meta-low)]`}
                     style={{ fontFamily: 'var(--font-body)' }}
                   >
-                    <span className="relative inline-flex h-[5px] w-[5px]">
-                      <span className="absolute inset-0 animate-ping rounded-full bg-[var(--color-kindra-green)] opacity-60" />
-                      <span className="relative inline-flex h-[5px] w-[5px] rounded-full bg-[var(--color-kindra-green)]" />
-                    </span>
-                    knowledge graph · active
+                    <span
+                      className="relative inline-flex h-[5px] w-[5px] rounded-full"
+                      style={{ background: 'var(--color-kindra-meta-low)' }}
+                    />
+                    private assistant · offline
                   </p>
                 </div>
                 <button

--- a/src/hooks/useJarvisChat.ts
+++ b/src/hooks/useJarvisChat.ts
@@ -17,7 +17,8 @@ export interface ChatMessage {
 }
 
 export const JARVIS_INTRO =
-  "Hey — I'm Jarvis, Matheus's personal AI. I know his projects, his thinking, his story. Ask me anything."
+  "Hey — I'm Jarvis, Matheus's personal AI. I'm private, so I'm offline for visitors right now. " +
+  'Want to talk to the real Matheus? Reach him through the contact page.'
 
 interface ApiResponse {
   response: string

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -101,7 +101,7 @@ export const projects: Project[] = [
   {
     title: 'Jarvis — Personal AI Operating System',
     description:
-      'My personal knowledge graph + AI agent. Connects memory, entities, tasks, and decisions across every project I touch. A living second brain built on MCP servers, vector search, and a growing taxonomy of what I know. This very page has a live Jarvis instance — ask it anything about me.',
+      'My personal knowledge graph + AI agent. Connects memory, entities, tasks, and decisions across every project I touch. A living second brain built on MCP servers, vector search, and a growing taxonomy of what I know. It is private by design — my own assistant, not a public chatbot.',
     tags: ['MCP', 'RAG', 'Vector DB', 'Personal AI', 'Knowledge Graph', 'Claude'],
     color: 'yellow',
     year: '2024-2026',
@@ -110,7 +110,7 @@ export const projects: Project[] = [
     role: 'personal ai os',
     coordinate: 'rag/mcp',
     nowNote:
-      'My personal knowledge graph + AI agent — the live instance answers questions right here on this site.',
+      'My personal knowledge graph + AI agent — a private second brain on MCP servers and vector search.',
     nowStatus: 'in-production',
   },
   {


### PR DESCRIPTION
## 🔴 Crítico — vazamento de dados pessoais + execução de comandos por visitantes anônimos

O chat público do portfólio estava conectado ao **Jarvis pessoal** do dono (`platform:'api'`), que o backend trata como o **próprio dono**: acesso total a contexto privado (perfil, **agenda**, **memória**, **documentos**) E poder de **executar ações** — foi observado **criando tarefas** a partir de mensagens de visitantes. Qualquer estranho podia ler dados pessoais e mutar o sistema do dono.

## Contenção (este PR)
- **`/api/ask` não chama mais o Jarvis.** Valida o input e retorna uma mensagem fixa ('offline para visitantes — fale pelo contato'). Verificado: tentativas de comando e de ler agenda → resposta fixa, backend nunca tocado.
- **Gate explícito**: o proxy só reativa com `JARVIS_PUBLIC_MODE='enabled'` (a chave sozinha não basta mais). Quando reativar, envia `platform:'public'` + `mode:'public_readonly'` + `allow_actions:false` — **mas o backend PRECISA garantir** um modo read-only sem dados pessoais antes de ligar essa env.
- **UI honesta**: status 'private · offline' (era 'knowledge graph · active' com dot verde); intro explica que é privado e aponta pro contato; chips de sugestão removidos; content.ts não afirma mais 'live Jarvis instance answers questions here'.

## ⚠️ Pendência no backend (fora deste repo)
Este PR contém o **portfólio**. O backend do Jarvis ainda trata `platform:'api'` como owner. Recomendado: **rotacionar a `JARVIS_API_KEY`** que estava na Vercel e garantir que nenhum `platform` público tenha dados pessoais ou ações.

Verificado: `tsc` + `next build` 0/0; contenção testada via curl + UI confirmada visualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Alterações**
  * O Jarvis agora está indisponível para visitantes públicos; acesso restrito ao modo privado.
  * Interface atualizada para exibir o status "offline" do assistente.
  * Sugestões de prompts iniciais removidas quando o assistente não está disponível.
  * Mensagens de apresentação atualizadas para refletir o acesso privado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->