### PR TITLE
fix(projetos): kill atlas label overlaps (15 nodes) by trimming node meta

### DIFF
--- a/src/app/projetos/page.tsx
+++ b/src/app/projetos/page.tsx
@@ -489,9 +489,10 @@ function ProjectNode({
         {String(index + 1).padStart(2, "0")}
       </span>
       <span className={styles.nodeLabel}>{title}</span>
-      <span className={styles.nodeMeta}>
-        / {signal} · {status}
-      </span>
+      {/* Meta is just the signal — status is already conveyed by the node's
+          color/ring and shown in the dossier; dropping '· {status}' keeps the
+          meta short enough that neighboring node labels never collide. */}
+      <span className={styles.nodeMeta}>/ {signal}</span>
     </button>
   );
 }

--- a/src/app/projetos/projects.module.css
+++ b/src/app/projetos/projects.module.css
@@ -556,14 +556,15 @@
 .nodeMeta {
   display: block;
   margin-top: 4px;
-  max-width: 96px;
+  /* Meta is just the short signal now (status dropped) — no wrap, no width
+     cap needed; it stays a single narrow line that can't reach a neighbor. */
+  white-space: nowrap;
   color: var(--color-kindra-meta-low);
   font-size: 8px;
   font-weight: 700;
   line-height: 1.4;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  overflow-wrap: anywhere;
 }
 
 .ledgerInner {


### PR DESCRIPTION
Follow-up do #49. Com 15 nós, os labels dos nós do atlas se sobrepunham. A raiz era a meta-line '/ {signal} · {status}' (ex: '/ vision · current') — longa demais: quebrava em 4 linhas (toque vertical Argus↔Detox) e transbordava na horizontal quando forçada a 1 linha (Jarvis↔MokLabs, CEIA↔Lofiever).

**Fix de raiz:** a meta agora é só o sinal ('/ vision'). O status já é transmitido pela cor/anel do nó e aparece completo no dossiê — era redundante. Isso resolve colisão em TODAS as direções de uma vez (tunar geometria era whack-a-mole).

**Verificação:** medição headless por ink de texto real em 1440 + 1280 — **0 overlap nos 105 pares de nós**, nada cortado. tsc + next build limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)