### PR TITLE
feat(projetos): hover-reveal atlas node names (cleaner 15-node layout)

### DIFF
--- a/src/app/projetos/page.tsx
+++ b/src/app/projetos/page.tsx
@@ -472,6 +472,7 @@ function ProjectNode({
     <button
       type="button"
       aria-pressed={isActive}
+      aria-label={title}
       onClick={onSelect}
       onMouseEnter={onSelect}
       className={`${styles.node} ${nodeStatusClass[status]}`}
@@ -488,10 +489,13 @@ function ProjectNode({
       <span className={styles.nodeIndex}>
         {String(index + 1).padStart(2, "0")}
       </span>
-      <span className={styles.nodeLabel}>{title}</span>
-      {/* Meta is just the signal — status is already conveyed by the node's
-          color/ring and shown in the dossier; dropping '· {status}' keeps the
-          meta short enough that neighboring node labels never collide. */}
+      {/* Default state: index + short signal only, so 15 nodes stay clean and
+          can spread out. The full name reveals on hover/focus (desktop) and
+          while selected (the tap state, so touch users still get it). It is
+          absolutely positioned so revealing it never reflows neighbors. */}
+      <span className={styles.nodeName} aria-hidden="true">
+        {title}
+      </span>
       <span className={styles.nodeMeta}>/ {signal}</span>
     </button>
   );

--- a/src/app/projetos/projects.module.css
+++ b/src/app/projetos/projects.module.css
@@ -451,14 +451,19 @@
   top: var(--node-y);
   left: var(--node-x);
   z-index: 4;
-  width: clamp(116px, 9vw, 158px);
-  min-height: 66px;
+  /* Compact now that the name is hover-only — the node is just the index +
+     a short signal line, centered. The full name floats below on reveal. */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 48px;
+  min-height: 48px;
   border: 0;
   background: transparent;
   padding: 0;
   color: var(--color-kindra-meta-low);
   font-family: var(--font-body);
-  text-align: left;
+  text-align: center;
   transform: translate(-50%, -50%);
   transition:
     opacity 260ms var(--ease-smooth),
@@ -487,14 +492,8 @@
   filter: drop-shadow(0 0 18px color-mix(in srgb, var(--node-accent) 30%, transparent));
 }
 
-/* Node size tracks orbit semantics: current > side > past (subtle). */
-.nodeSide {
-  width: clamp(106px, 8vw, 136px);
-}
-
-.nodePast {
-  width: clamp(96px, 7vw, 120px);
-}
+/* Node size tracks orbit semantics via the index box (current > side > past,
+   set on .nodeIndex below) — the node container itself is a fixed 48px. */
 
 .nodeIndex {
   display: inline-flex;
@@ -527,30 +526,45 @@
   color: var(--color-kindra-on-accent);
 }
 
-.nodeLabel {
-  display: block;
-  margin-top: 8px;
-  /* Cap the text width so neighboring nodes' labels don't bleed into each
-     other — the box stays a comfortable tap target, only the text wraps
-     narrower. Critical now that the atlas carries 15 bodies. */
-  max-width: 92px;
-  color: var(--color-kindra-meta-mid);
+/* Project name — hidden by default so the 15-node atlas stays clean and the
+   nodes can spread out. Revealed on hover/focus (desktop) and while selected
+   (the tap state — so touch users get it too). Absolutely positioned below
+   the index so showing it never reflows or collides with neighbors. */
+.nodeName {
+  position: absolute;
+  top: calc(100% + 7px);
+  left: 50%;
+  z-index: 6;
+  width: max-content;
+  max-width: 150px;
+  padding: 4px 8px;
+  transform: translate(-50%, -4px);
+  border: 1px solid var(--node-border);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-kindra-bg) 90%, transparent);
+  backdrop-filter: blur(4px);
+  color: var(--color-kindra-cream);
   font-size: 10px;
   font-weight: 800;
-  line-height: 1.3;
-  letter-spacing: 0.16em;
+  line-height: 1.25;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  overflow-wrap: anywhere;
+  text-align: center;
+  white-space: normal;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 220ms var(--ease-smooth),
+    transform 220ms var(--ease-smooth);
 }
 
-.nodeSide .nodeLabel,
-.nodePast .nodeLabel {
-  font-size: 9px;
-  letter-spacing: 0.14em;
-}
-
-.node[aria-pressed="true"] .nodeLabel {
-  color: var(--color-kindra-cream);
+.node:hover .nodeName,
+.node:focus-visible .nodeName,
+.node[aria-pressed="true"] .nodeName {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
 }
 
 .nodeMeta {


### PR DESCRIPTION
Os nomes dos 15 projetos sempre visíveis poluíam o atlas e forçavam nós largos, amontoando a constelação (como no print). Agora:

- **Padrão:** cada nó mostra só o índice (01..15) + signal curto ('/ memory').
- **Nome revela no hover/foco** (desktop) num chip flutuante, e **no nó selecionado** (o estado de tap — então touch também vê; o dossiê e a build-ledger sempre listam os nomes).
- Nós compactos (48px, centrados) → os 15 corpos se espalham limpos em órbitas concêntricas, **sem aglomeração e sem colisão de labels**. Nome mantido em `aria-label` p/ acessibilidade.

Resolve de vez a tensão de layout do atlas de 15 nós (era a raiz das colisões que vínhamos perseguindo). Verificado headless em 1440: nomes ocultos por padrão, chip de hover legível, selecionado nomeado, distribuição limpa. tsc + next build 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)