### PR TITLE
fix(shell): stop content from clipping the Pixi explosion (z-index)

### DIFF
--- a/src/components/layout/shell.module.css
+++ b/src/components/layout/shell.module.css
@@ -7,7 +7,12 @@
 
 .shell {
   position: relative;
-  z-index: var(--z-content);
+  /* z-0: the shell sits in the SAME plane as the fixed Pixi background canvas
+     (also z-0), so the black-hole / explosion behind it is never clipped by
+     the shell's box. The readable content lifts to z-1 via .scroll below.
+     (Previously z-10 put the whole shell above the canvas, so the centered
+     1280px box visually cut off the explosion expanding outside it.) */
+  z-index: 0;
   width: 100%;
   max-width: var(--shell-max-w);
   height: 100vh;
@@ -22,7 +27,9 @@
    content reflows naturally (previously only /projetos had this fallback). */
 .scroll {
   position: relative;
-  z-index: var(--z-content);
+  /* z-1: readable content sits just above the Pixi background plane (z-0),
+     without forcing the whole shell above it. */
+  z-index: 1;
   height: 100%;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
O conteúdo estava cortando a explosão do black hole (visível na entrada do /skills — os anéis da animação cortados num retângulo).

**Causa:** o `.shell` estava em `z-index: 10`, **acima** do canvas Pixi do fundo (z-0). A caixa de conteúdo centralizada (1280px) recortava visualmente a explosão quando os anéis expandiam pra fora dela.

**Fix (o que você indicou):**
- `.shell` → `z-index: 0` (mesmo plano do canvas, transparente, não clipa)
- conteúdo (`.scroll`) → `z-index: 1` (acima do fundo, legível)
- chrome (z-30) e camadas de explode/transição seguem acima do conteúdo dentro do contexto do shell.

**Verificado** headless em 1440 nas 4 rotas: explosão renderiza como anéis concêntricos completos (sem corte retangular), nenhuma rota perdeu o fundo, texto legível, chrome no topo, nav funcionando. build 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)