### PR TITLE
fix(shell): text no longer dimmed by the reading scrim (z-index)

### DIFF
--- a/src/components/layout/shell.module.css
+++ b/src/components/layout/shell.module.css
@@ -7,12 +7,14 @@
 
 .shell {
   position: relative;
-  /* z-0: the shell sits in the SAME plane as the fixed Pixi background canvas
-     (also z-0), so the black-hole / explosion behind it is never clipped by
-     the shell's box. The readable content lifts to z-1 via .scroll below.
-     (Previously z-10 put the whole shell above the canvas, so the centered
-     1280px box visually cut off the explosion expanding outside it.) */
-  z-index: 0;
+  /* z-3: the shell (transparent box) sits ABOVE the reading scrim (z-2) and
+     the grain (z-2) so route text is never dimmed by them — the bug where the
+     left scrim painted over the /skills quote. It's still transparent, so the
+     fixed Pixi background canvas (z-0) and its black-hole explosion show
+     through and are NOT clipped (overflow:hidden only clips the shell's own
+     children, not the sibling canvas). Was z-0, which let the z-2 scrim cover
+     the text; was z-10 before that, which is unrelated to the explosion clip. */
+  z-index: 3;
   width: 100%;
   max-width: var(--shell-max-w);
   height: 100vh;


### PR DESCRIPTION
O texto das rotas (a quote do /skills no print) aparecia **abaixo de uma camada preta** — apagado. Causa: o scrim de leitura (ContentScrim, fixed z-2, gradiente escuro à esquerda) estava pintando **por cima** do texto. Isso surgiu quando um fix anterior baixou o shell pra z-0 (pra não cortar a explosão do black hole) — aí o scrim z-2 passou a ficar acima do conteúdo do shell.

**Fix:** shell → `z-index: 3` (acima do scrim z-2 e do grain z-2), então o texto volta pro topo. O shell é transparente → o canvas Pixi (z-0) e a explosão continuam aparecendo através e **não são cortados**. O scrim segue em z-2, abaixo do shell, escurecendo a foto/black-hole atrás do texto sem cobri-lo.

**Verificado** headless em 1440 nas 4 rotas: quote branca nítida (hit-test = blockquote, não o scrim), explosão inteira (não cortada), scrims da home/sobre ainda escurecem os retratos, chrome no topo, nav OK. tsc + next build 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)