### PR TITLE
docs(readme): give it a voice + correct the facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,74 @@
-# Matheus Kindrazki
+<h1 align="center">Matheus Kindrazki</h1>
 
-**Co-founder & Builder** at MokLabs Venture Studio · founding team at Lugui.ai
-Building ventures where bold ideas meet careful engineering.
+<p align="center">
+  <strong>Founder &amp; Principal Engineer of AI</strong><br>
+  I build ventures where bold ideas meet careful engineering.
+</p>
 
-[@kindraScript](https://x.com/kindraScript) • [matheus@kindrazki.dev](mailto:matheus@kindrazki.dev) • [kindrazki.dev](https://kindrazki.dev) • Curitiba, Brazil
+<p align="center">
+  <a href="https://matheuskindrazki.dev">matheuskindrazki.dev</a> ·
+  <a href="https://linkedin.com/in/matheuskindrazki">LinkedIn</a> ·
+  <a href="https://matheuskindrazki.medium.com">Medium</a> ·
+  <a href="https://x.com/kindraScript">X</a> ·
+  <a href="mailto:matheus@kindrazki.dev">Email</a><br>
+  <sub>Curitiba, Brazil · −25.42° −49.27°</sub>
+</p>
 
 ---
 
-## About
+## Who I am
 
-Co-founder at MokLabs Venture Studio and part of the founding team at Lugui.ai. Engineering since 2017, architecting platforms used by millions of students — now turning that experience into products of my own. Technology adventurer, pragmatic builder.
+I'm an entrepreneur and Principal Engineer who spent nearly a decade architecting platforms used by millions of students — and is now turning that experience into products of my own.
 
-I approach problems with analytical depth and a preference for **mechanisms over magic**: governance frameworks (RFCs/ADRs), canonical documentation, observable pipelines, and automation that makes the right thing the easy thing. AI applied as engineering — observability, evaluation, datasets, and metrics; not magic.
+I think in systems. I like understanding a problem deeply before touching it, then building the kind of solution that holds up: predictable, observable, documented, and automated so the right thing becomes the easy thing. I care about results that are real and durable over things that just look impressive — **mechanisms over magic**.
 
-## What I'm Building
+Off the clock I'm a musician and a DJ, the piano is my favorite instrument, and — turns out — I also know how to make rubber. Creativity doesn't stop at the code.
 
-- **MokLabs Venture Studio** — Co-founded AI venture studio turning sharp ideas into shipped products. Shared platform engineering, design systems, and AI infrastructure power a portfolio of ventures.
-- **Lugui.ai** — Founding team member building AI-native educational intelligence from day zero — tutoring systems that actually understand what a student just missed.
-- **Jarvis** — My personal knowledge graph + AI agent. Connects memory, entities, tasks, and decisions across every project I touch.
-- **Synk** — A real code editor for the iPad with on-device AI. Native SwiftUI + Runestone, cloud AI plus an opt-in local model via MLC-LLM.
-- **Argus** — Privacy-first, camera-agnostic security platform with AI vision. Connects to any ONVIF/RTSP camera — no rip-and-replace.
-- **Kindraw** — A warm, playful workspace built on top of Excalidraw — authenticated boards, markdown docs with Mermaid, and real-time collaboration.
+## What I'm building
 
-### On the Side
+**[MokLabs Venture Studio](https://matheuskindrazki.dev/projetos)** — Co-founder. An AI venture studio that turns sharp ideas into shipped products: shared platform engineering, design systems, and AI infrastructure so each new venture reuses the scaffolding instead of rebuilding it.
 
-- **[Remindr.AI](https://remindr.ai)** — Privacy-first desktop app for intelligent transcription, diarization, and daily memory. Built for people who think while they talk.
+**[Lugui.ai](https://lugui.ai)** — Founding team. AI infrastructure for the real-estate market — *"the intelligence of your agency, inside WhatsApp."* Conversational agents and RAG pipelines that let realtors qualify leads, answer about listings, and close deals where their clients already are.
+
+**CEIA (UFG)** — AI Research Fellow. Applied research at the frontier of LLMs and intelligent systems, bridging academic rigor and shipped products.
+
+**Jarvis** — My personal knowledge graph + AI agent. A private second brain on MCP servers and vector search, connecting memory, entities, tasks, and decisions across every project I touch.
+
+### Own products
+
+- **[FastShared](https://fastsha.red)** — Ephemeral file sharing as a single gesture: pick a file, set how long the link lives, get a URL that vanishes on its own. Apple-native + a CLI built as a file-handoff primitive for AI agents.
+- **Lavra** — A native macOS app that transcribes audio to clean text fully offline on Apple Silicon (WhisperKit + Apple Foundation Models). Strong Portuguese-BR support; nothing leaves the device.
+- **ScreenshotDetox** — Turns your screenshot pile into an inbox of decisions, entirely on-device (Apple Vision OCR + a local classifier).
+- **Synk** — A real code editor for the iPad with on-device AI (SwiftUI + Runestone, cloud AI plus an opt-in local model via MLC-LLM).
+- **[Remindr.AI](https://remindr.ai)** — Privacy-first desktop app for intelligent transcription, diarization, and daily memory — for people who think while they talk.
+- **Kindraw** — A warm, playful workspace on top of Excalidraw: authenticated boards, markdown docs with Mermaid, and real-time collaboration.
 - **Lofiever** — A 24/7 lo-fi streaming app with an AI DJ that curates the playlist and talks back in chat.
 
-## Before: Arco Educação (2020–2024)
+## Before — Arco Educação (2020–2026)
 
-Joined the largest education company in Brazil as a frontend engineer in 2020, became Tech Lead in 2022 and Principal Engineer in 2024:
+Nearly six years at one of Brazil's largest edtechs. I joined as a Software Engineer, stepped up to Staff with microfrontend architecture, and consolidated as **Principal Engineer of AI**.
 
-- Architected the microfrontend ecosystem with Module Federation, enabling independent squad velocity while maintaining system coherence across product surfaces reaching millions of students.
-- Built AI education tools: RAG systems over 10k+ document bases, automated essay correction with OCR/HTR pipelines, and semantic search infrastructure.
-- Led design-system integration and governance, plus DX initiatives — canonical documentation, RFC/ADR processes, CI/CD standardization.
-- Seeded **Café com Código**, a recurring engineering community ritual for knowledge sharing and technical culture building.
+- Architected the microfrontend ecosystem with Module Federation, enabling independent squad velocity while keeping system coherence across product surfaces reaching millions of students.
+- Led design-system integration and governance, plus DX — canonical documentation, RFC/ADR processes, CI/CD standardization.
+- **Last delivery:** the AI essay-correction platform for the ENEM exam. I led the core pipeline (ingestion, classification, analysis) and owned the **computer-vision model that reads handwritten essays** (OCR/HTR) over a queued, real-time correction system feeding teachers.
+- Seeded **Café com Código**, a recurring engineering ritual for knowledge sharing and technical culture.
 
-## Engineering Philosophy
+## How I think
 
-- **Coherence over cleverness** — systems should be predictable, not impressive
-- **Governance as enabler** — lightweight structures (RFCs, ADRs) that prevent chaos without bureaucracy
-- **DX as leverage** — remove friction and teams move faster with higher quality
-- **AI as engineering** — observability, evaluation, datasets, and metrics; not magic
-- **Documentation as source of truth** — canonical, versioned, discoverable
-- **Pragmatic depth** — deep enough to be correct, simple enough to be maintainable
+- **Coherence over cleverness** — systems should be predictable, not impressive.
+- **Governance as enabler** — lightweight structures (RFCs, ADRs) that prevent chaos without bureaucracy.
+- **DX as leverage** — remove friction and teams move faster with higher quality.
+- **AI as engineering** — observability, evaluation, datasets, and metrics; not magic.
+- **Documentation as source of truth** — canonical, versioned, discoverable.
+- **Pragmatic depth** — deep enough to be correct, simple enough to be maintainable.
 
 ## Stack
 
-**Frontend Architecture & Platform** — React • Next.js • TypeScript • Module Federation • Micro Frontends • Design Systems
-**Applied AI & Agents** — LangChain • LangGraph • RAG Orchestration • MCP Servers • Vector DBs • On-device AI
-**Full-Stack & Native** — Node.js • Python • PHP • Rust • SwiftUI • Tauri • GraphQL • PostgreSQL
-**Cloud & Infrastructure** — AWS • Azure • Cloudflare • Docker • Coolify • Supabase • Edge Functions
+**Frontend Architecture & Platform** — React · Next.js · TypeScript · Module Federation · Micro Frontends · Design Systems
+**Applied AI & Agents** — LangChain · LangGraph · RAG Orchestration · MCP Servers · Vector DBs · On-device AI · OCR/HTR · Computer Vision
+**Full-Stack & Native** — Node.js · Python · PHP · Rust · SwiftUI · Tauri · GraphQL · PostgreSQL
+**Cloud & Infrastructure** — AWS · Azure · Cloudflare · Docker · Coolify · Supabase · Edge Functions
 
 ---
 
-**Building coherent systems, one mechanism at a time.**
+<p align="center"><sub>Building coherent systems, one mechanism at a time.</sub></p>


### PR DESCRIPTION
O README estava sem persona e com vários fatos desatualizados. Reescrito em primeira pessoa com uma voz clara (empresário + Principal Engineer of AI, 'mechanisms over magic', uma linha humana sobre música/piano/borracha) e com os fatos batendo com o site no ar:

- **Lugui** é infra de IA pro mercado imobiliário (WhatsApp), não plataforma educacional.
- **Arco** 2020–2026, Principal Engineer of AI; adiciona a última entrega (correção de redação do ENEM + o modelo de visão computacional que liderei).
- Adiciona o **CEIA (UFG)** e os produtos novos (FastShared, Lavra, ScreenshotDetox).
- Domínio morto kindrazki.dev → matheuskindrazki.dev (email mantido).

(Respeitada a preferência de descrever como Empresário/Principal Engineer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * O README foi reorganizado com um visual mais moderno, incluindo novo cabeçalho, links sociais e seções com layout atualizado.
  * A apresentação dos produtos foi refinada, com novos itens destacados e ajustes na organização do conteúdo.
  * A seção de histórico profissional foi atualizada com novas informações e prazo estendido.
  * A área de tecnologias e o rodapé também foram revisados para manter consistência visual e textual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->